### PR TITLE
Remove WP_WEBHOOK_FRAMEWORK_URL constant, document multi-instance pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ Ensure Action Scheduler is active (dependency is declared).
 \Citation\WP_Webhook_Framework\Service_Provider::register();
 ```
 
-### Configuration
-
-```php
-// wp-config.php
-define('WP_WEBHOOK_FRAMEWORK_URL', 'https://api.example.com/webhook');
-```
-
 See [Configuration](./docs/configuration.md) for detailed configuration options.
 
 ## Usage Examples
@@ -56,6 +49,27 @@ if ($post_webhook) {
                  ->timeout(60)
                  ->notifications(['blocked']); // Enable email notifications
 }
+```
+
+### Multiple Endpoints for the Same Entity
+
+Multiple plugins can each register their own webhook instance for the same
+entity type. Each instance gets independent URL, retry policy, timeout, and
+failure tracking:
+
+```php
+add_action('wpwf_register_webhooks', function ($registry) {
+    $analytics = new \Citation\WP_Webhook_Framework\Webhooks\Post_Webhook('post_analytics');
+    $analytics->webhook_url('https://analytics.example.com/posts')
+              ->timeout(10);
+    $registry->register($analytics);
+
+    $crm = new \Citation\WP_Webhook_Framework\Webhooks\Post_Webhook('post_crm');
+    $crm->webhook_url('https://crm.example.com/webhook')
+        ->max_retries(5)
+        ->timeout(60);
+    $registry->register($crm);
+});
 ```
 
 ### Create Custom Webhook
@@ -126,7 +140,7 @@ See [Hooks and Filters](./docs/hooks-and-filters.md) for all available hooks and
 
 **Stateless (configuration):**
 ```php
-// Set once during __construct()
+// Set once during __construct() or via registry
 $this->webhook_url('https://api.example.com')
      ->max_consecutive_failures(5);
 ```

--- a/docs/custom-webhooks.md
+++ b/docs/custom-webhooks.md
@@ -158,6 +158,25 @@ class Gravity_Forms_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
 }
 ```
 
+## Multiple Endpoints for the Same Entity
+
+Register additional instances of a built-in webhook class with a unique name.
+Each instance has its own URL, retry policy, timeout, and failure tracking:
+
+```php
+add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
+    $analytics = new \Citation\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_analytics' );
+    $analytics->webhook_url( 'https://analytics.example.com/posts' )
+              ->timeout( 10 );
+    $registry->register( $analytics );
+} );
+```
+
+This is recommended over modifying the built-in webhooks whenever different
+endpoints require different configuration (timeouts, retries, headers, etc.).
+
+See [Configuration](./configuration.md#multiple-endpoints-for-the-same-entity) for a detailed example.
+
 ## Conditional Registration
 
 Check plugin availability before registering:

--- a/docs/hooks-and-filters.md
+++ b/docs/hooks-and-filters.md
@@ -119,8 +119,6 @@ Filter the webhook URL before scheduling.
 
 **Returns:** string
 
-**Note:** `WP_WEBHOOK_FRAMEWORK_URL` constant always takes precedence.
-
 ```php
 // Route by entity type
 add_filter( 'wpwf_url', function ( string $url, string $entity, int|string $id ): string {
@@ -302,6 +300,5 @@ Filters are applied in this order:
 
 1. `wpwf_payload` - Modify or prevent payload
 2. `wpwf_url` - Customize webhook URL
-3. `WP_WEBHOOK_FRAMEWORK_URL` constant - Overrides filtered URL
-4. `wpwf_headers` - Customize HTTP headers
-5. `wpwf_excluded_meta` - Filter meta keys (meta webhooks only)
+3. `wpwf_headers` - Customize HTTP headers
+4. `wpwf_excluded_meta` - Filter meta keys (meta webhooks only)

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -37,17 +37,8 @@ class Dispatcher {
 			throw new WP_Exception( 'action_scheduler_not_active' );
 		}
 
-		// Apply filter if no webhook-specific URL was set
+		// Allow filters to modify or set the URL at dispatch time
 		$url = apply_filters( 'wpwf_url', $url, $entity, $id );
-
-		// Constants always take precedence over filters for reliability
-		if (
-			defined( 'WP_WEBHOOK_FRAMEWORK_URL' )
-			&& WP_WEBHOOK_FRAMEWORK_URL !== ''
-			&& is_string( WP_WEBHOOK_FRAMEWORK_URL )
-		) {
-			$url = WP_WEBHOOK_FRAMEWORK_URL;
-		}
 
 		if ( empty( $url ) ) {
 			throw new WP_Exception( 'webhook_url_not_set' );


### PR DESCRIPTION
## Summary

- **Remove `WP_WEBHOOK_FRAMEWORK_URL` constant** from `Dispatcher` — the global constant forced all webhooks to a single URL, preventing independent configuration per endpoint.
- **Document the multi-instance pattern** for multiple plugins needing the same entity type: register separate webhook instances with unique names, each with its own URL, retries, timeout, and failure tracking.
- **Update all docs** (README, configuration, custom-webhooks, hooks-and-filters) to remove constant references and add multi-instance examples.

## Breaking Change

`WP_WEBHOOK_FRAMEWORK_URL` constant is no longer supported. Use `webhook_url()` on individual webhook instances or the `wpwf_url` filter instead.

## Why

The constant override conflicted with the multi-instance registry pattern. When multiple plugins register their own webhook instances for the same entity, a global constant would override all their independently configured URLs — defeating the purpose of per-webhook configuration.