### PR TITLE
Remove enabled flag, make webhook registration fully opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,22 @@ See [Configuration](./docs/configuration.md) for detailed configuration options.
 
 ## Usage Examples
 
-### Configure Built-in Webhooks
+### Register Webhooks
+
+No webhooks are active by default. Register what you need via the action:
 
 ```php
-$registry = \Citation\WP_Webhook_Framework\Service_Provider::get_registry();
+use Citation\WP_Webhook_Framework\Webhooks\Post_Webhook;
 
-$post_webhook = $registry->get('post');
-if ($post_webhook) {
-    $post_webhook->webhook_url('https://api.example.com/posts')
-                 ->max_retries(3)
-                 ->max_consecutive_failures(5)
-                 ->timeout(60)
-                 ->notifications(['blocked']); // Enable email notifications
-}
+add_action('wpwf_register_webhooks', function ($registry) {
+    $post = new Post_Webhook();
+    $post->webhook_url('https://api.example.com/posts')
+         ->max_retries(3)
+         ->max_consecutive_failures(5)
+         ->timeout(60)
+         ->notifications(['blocked']);
+    $registry->register($post);
+});
 ```
 
 ### Multiple Endpoints for the Same Entity
@@ -88,10 +91,6 @@ class Custom_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
     }
     
     public function init(): void {
-        if (!$this->is_enabled()) {
-            return;
-        }
-        
         add_action('my_custom_action', [$this, 'handle_action'], 10, 1);
     }
     

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,6 @@ Configure individual webhooks using chainable methods.
 | `max_consecutive_failures(int)` | Failures before blocking (0 disables) | 10 |
 | `max_retries(int)` | Retry attempts per failed event | 0 |
 | `timeout(int)` | HTTP timeout in seconds (1-300) | 10 |
-| `enabled(bool)` | Enable/disable webhook | true |
 | `headers(array)` | Custom HTTP headers | [] |
 | `notifications(array)` | Enable notification handlers | [] |
 
@@ -29,29 +28,25 @@ $webhook->webhook_url( 'https://api.example.com' )
 
 ## Registry Configuration
 
-Access and configure webhooks through the registry:
+Register webhooks via the `wpwf_register_webhooks` action. No webhooks are
+active by default -- only those you explicitly register:
 
 ```php
-$registry = Service_Provider::get_registry();
+use Citation\WP_Webhook_Framework\Webhooks\Post_Webhook;
+use Citation\WP_Webhook_Framework\Webhooks\Meta_Webhook;
 
-$post_webhook = $registry->get( 'post' );
-if ( null !== $post_webhook ) {
-    $post_webhook->webhook_url( 'https://api.example.com/posts' )
-                 ->max_consecutive_failures( 3 )
-                 ->timeout( 30 );
-}
-```
-
-## Notification Configuration
-
-Notifications are **opt-in** per webhook. Enable specific handlers:
-
-```php
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
-    $post_webhook = $registry->get( 'post' );
-    if ( null !== $post_webhook ) {
-        $post_webhook->notifications( array( 'blocked' ) );
-    }
+    $post = new Post_Webhook();
+    $post->webhook_url( 'https://api.example.com/posts' )
+         ->max_consecutive_failures( 3 )
+         ->timeout( 30 )
+         ->notifications( array( 'blocked' ) );
+    $registry->register( $post );
+
+    $meta = new Meta_Webhook();
+    $meta->webhook_url( 'https://api.example.com/posts' )
+         ->emission_mode( Meta_Webhook::EMIT_ENTITY );
+    $registry->register( $meta );
 } );
 ```
 

--- a/docs/custom-webhooks.md
+++ b/docs/custom-webhooks.md
@@ -20,10 +20,6 @@ class Custom_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
     }
     
     public function init(): void {
-        if ( ! $this->is_enabled() ) {
-            return;
-        }
-        
         add_action( 'my_custom_action', array( $this, 'handle_action' ) );
     }
     
@@ -51,7 +47,6 @@ add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): v
 | `max_retries(int)` | Retry attempts per failed event | 0 |
 | `max_consecutive_failures(int)` | Failures before blocking (0 disables) | 10 |
 | `timeout(int)` | HTTP timeout in seconds (1-300) | 10 |
-| `enabled(bool)` | Enable/disable webhook | true |
 | `webhook_url(string)` | Custom endpoint URL | None |
 | `headers(array)` | Additional HTTP headers | [] |
 | `notifications(array)` | Notification handlers to enable | [] |
@@ -74,10 +69,6 @@ class WooCommerce_Order_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
     }
     
     public function init(): void {
-        if ( ! $this->is_enabled() ) {
-            return;
-        }
-        
         add_action( 'woocommerce_new_order', array( $this, 'on_new_order' ) );
         add_action( 'woocommerce_order_status_changed', array( $this, 'on_status_changed' ), 10, 4 );
     }
@@ -110,10 +101,6 @@ class CF7_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
     }
     
     public function init(): void {
-        if ( ! $this->is_enabled() ) {
-            return;
-        }
-        
         add_action( 'wpcf7_mail_sent', array( $this, 'on_submit' ) );
     }
     
@@ -142,10 +129,6 @@ class Gravity_Forms_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
     }
     
     public function init(): void {
-        if ( ! $this->is_enabled() ) {
-            return;
-        }
-        
         add_action( 'gform_after_submission', array( $this, 'on_submit' ), 10, 2 );
     }
     
@@ -226,7 +209,7 @@ See [Webhook Statefulness](./webhook-statefulness.md) for details.
 
 ## Best Practices
 
-1. **Check `is_enabled()`** in `init()` before registering hooks
+1. **Only register what you need** - registering a webhook activates it immediately
 2. **Check plugin existence** before registering integration webhooks
 3. **Keep webhooks stateless** - pass data to `emit()`, don't store on instance
 4. **Use meaningful names** - lowercase with underscores

--- a/docs/hooks-and-filters.md
+++ b/docs/hooks-and-filters.md
@@ -255,26 +255,6 @@ Filter the final calculated retry delay.
 add_filter( 'wpwf_retry_delay', fn() => 300 );
 ```
 
-### `wpwf_webhook_enabled`
-
-Filter whether a webhook is enabled.
-
-**Parameters:**
-- `$enabled` (bool) - Whether enabled
-- `$webhook_name` (string) - The webhook name
-
-**Returns:** bool
-
-```php
-// Disable during maintenance
-add_filter( 'wpwf_webhook_enabled', function ( bool $enabled, string $webhook_name ): bool {
-    if ( defined( 'WP_MAINTENANCE_MODE' ) && WP_MAINTENANCE_MODE ) {
-        return false;
-    }
-    return $enabled;
-}, 10, 2 );
-```
-
 ## Payload Structure
 
 Standard payload sent with all webhooks:

--- a/docs/webhook-statefulness.md
+++ b/docs/webhook-statefulness.md
@@ -24,7 +24,6 @@ public function init(): void {
 Configuration methods:
 - `max_consecutive_failures()` - Retry policy
 - `timeout()` - Request timeout
-- `enabled()` - Enable/disable webhook
 - `webhook_url()` - Custom endpoint URL
 - `headers()` - Static headers (auth tokens, API keys)
 

--- a/src/Service_Provider.php
+++ b/src/Service_Provider.php
@@ -9,17 +9,13 @@ declare(strict_types=1);
 
 namespace Citation\WP_Webhook_Framework;
 
-use Citation\WP_Webhook_Framework\Webhooks\Post_Webhook;
-use Citation\WP_Webhook_Framework\Webhooks\Term_Webhook;
-use Citation\WP_Webhook_Framework\Webhooks\User_Webhook;
-use Citation\WP_Webhook_Framework\Webhooks\Meta_Webhook;
 use Citation\WP_Webhook_Framework\Notifications\Blocked;
 use Citation\WP_Webhook_Framework\Notifications\Notification_Registry;
 
 /**
- * Class Service_Provider
- *
- * Registers WordPress hooks and wires entity handlers to the dispatcher using the registry pattern.
+ * Bootstraps the framework by wiring up the Dispatcher, Registry, and
+ * Notification system. Does not register any webhooks -- consumers must
+ * register their own via the `wpwf_register_webhooks` action.
  */
 class Service_Provider {
 
@@ -94,24 +90,20 @@ class Service_Provider {
 	}
 
 	/**
-	 * Register webhooks using the registry pattern.
+	 * Fire the registration action so consumers can register webhooks.
+	 *
+	 * No webhooks are registered by default. Consumers choose which
+	 * webhooks to register via the `wpwf_register_webhooks` action.
+	 * Each call to `Webhook_Registry::register()` immediately calls
+	 * `init()` on the webhook, so hooks are active right away.
 	 */
 	private function register_webhooks(): void {
-		// Register core webhooks with default configuration
-		$this->registry->register( new Post_Webhook() );
-		$this->registry->register( new Term_Webhook() );
-		$this->registry->register( new User_Webhook() );
-		$this->registry->register( new Meta_Webhook() );
-
 		/**
-		 * Allow third parties to register custom webhooks.
+		 * Register webhooks with the framework.
 		 *
 		 * @param Webhook_Registry $registry The webhook registry instance.
 		 */
 		do_action( 'wpwf_register_webhooks', $this->registry );
-
-		// Initialize all registered webhooks
-		$this->registry->init_all();
 	}
 
 	/**

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -63,13 +63,6 @@ abstract class Webhook {
 	protected int $timeout = 30;
 
 	/**
-	 * Whether this webhook is enabled.
-	 *
-	 * @var bool
-	 */
-	protected bool $enabled = true;
-
-	/**
 	 * Custom webhook URL (optional).
 	 *
 	 * @var string
@@ -139,17 +132,6 @@ abstract class Webhook {
 	 */
 	public function timeout( int $timeout ): static {
 		$this->timeout = max( 1, min( self::MAX_TIMEOUT, $timeout ) );
-		return $this;
-	}
-
-	/**
-	 * Enable or disable this webhook.
-	 *
-	 * @param bool $enabled Whether the webhook is enabled.
-	 * @return static
-	 */
-	public function enabled( bool $enabled = true ): static {
-		$this->enabled = $enabled;
 		return $this;
 	}
 
@@ -287,23 +269,6 @@ abstract class Webhook {
 		 * @param string $webhook_name The webhook name/identifier.
 		 */
 		return (int) apply_filters( 'wpwf_timeout', $this->timeout, $this->name );
-	}
-
-	/**
-	 * Check if this webhook is enabled.
-	 *
-	 * Applies 'wpwf_webhook_enabled' filter for runtime modification.
-	 *
-	 * @return bool
-	 */
-	public function is_enabled(): bool {
-		/**
-		 * Filter whether the webhook is enabled.
-		 *
-		 * @param bool   $enabled      Whether the webhook is enabled.
-		 * @param string $webhook_name The webhook name/identifier.
-		 */
-		return (bool) apply_filters( 'wpwf_webhook_enabled', $this->enabled, $this->name );
 	}
 
 	/**

--- a/src/Webhooks/Meta_Webhook.php
+++ b/src/Webhooks/Meta_Webhook.php
@@ -47,10 +47,6 @@ class Meta_Webhook extends Webhook {
 	 * Initialize the webhook by registering WordPress hooks.
 	 */
 	public function init(): void {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
 		add_action( 'deleted_post_meta', array( $this, 'on_deleted_post_meta' ), 10, 4 );
 		add_action( 'deleted_term_meta', array( $this, 'on_deleted_term_meta' ), 10, 4 );
 		add_action( 'deleted_user_meta', array( $this, 'on_deleted_user_meta' ), 10, 4 );

--- a/src/Webhooks/Post_Webhook.php
+++ b/src/Webhooks/Post_Webhook.php
@@ -44,10 +44,6 @@ class Post_Webhook extends Webhook {
 	 * Initialize the webhook by registering WordPress hooks.
 	 */
 	public function init(): void {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
 		add_action( 'save_post', array( $this, 'on_save_post' ), 10, 3 );
 		add_action( 'before_delete_post', array( $this, 'on_delete_post' ), 10, 1 );
 	}

--- a/src/Webhooks/Term_Webhook.php
+++ b/src/Webhooks/Term_Webhook.php
@@ -44,10 +44,6 @@ class Term_Webhook extends Webhook {
 	 * Initialize the webhook by registering WordPress hooks.
 	 */
 	public function init(): void {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
 		add_action( 'created_term', array( $this, 'on_created_term' ), 10, 3 );
 		add_action( 'edited_term', array( $this, 'on_edited_term' ), 10, 3 );
 		add_action( 'delete_term', array( $this, 'on_deleted_term' ), 10, 3 );

--- a/src/Webhooks/User_Webhook.php
+++ b/src/Webhooks/User_Webhook.php
@@ -44,10 +44,6 @@ class User_Webhook extends Webhook {
 	 * Initialize the webhook by registering WordPress hooks.
 	 */
 	public function init(): void {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
 		add_action( 'user_register', array( $this, 'on_user_register' ), 10, 1 );
 		add_action( 'profile_update', array( $this, 'on_profile_update' ), 10, 1 );
 		add_action( 'deleted_user', array( $this, 'on_deleted_user' ), 10, 1 );


### PR DESCRIPTION
## Summary

- **Remove `$enabled` property**, `enabled()`, `is_enabled()` methods from `Webhook`
- **Remove `wpwf_webhook_enabled` filter**
- **Remove `get_enabled()` and `init_all()`** from `Webhook_Registry`
- **Stop auto-registering core webhooks** in `Service_Provider` -- consumers register only what they need via `wpwf_register_webhooks`
- **Fix double-init bug** where `register()` and `init_all()` both called `init()` on the same instances
- **Update all docs** (README, configuration, custom-webhooks, hooks-and-filters, webhook-statefulness)

## Why

Registering a webhook instance IS enabling it. The `enabled` flag was only needed because `Service_Provider` auto-registered all 4 core webhooks, requiring an opt-out mechanism. With explicit registration, the flag is redundant -- you simply don't register what you don't want.

## Breaking Changes

- `Webhook::enabled()` and `Webhook::is_enabled()` removed
- `wpwf_webhook_enabled` filter removed
- `Webhook_Registry::get_enabled()` and `Webhook_Registry::init_all()` removed
- Core webhooks (post, term, user, meta) are no longer registered by default

## Migration

Before:
```php
Service_Provider::register();
// All 4 webhooks active, disable what you don't need
add_filter('wpwf_webhook_enabled', fn($e, $n) => $n !== 'term' ? $e : false, 10, 2);
```

After:
```php
Service_Provider::register();
add_action('wpwf_register_webhooks', function ($registry) {
    $post = new Post_Webhook();
    $post->webhook_url('https://api.example.com/posts');
    $registry->register($post);
});
```