### PR TITLE
update the namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Code Style
 - **PHP 8.0+ library** with WordPress coding standards (WPCS 3.1)
-- **Namespace**: `Citation\WP_Webhook_Framework` (PSR-4)
+- **Namespace**: `juvo\WP_Webhook_Framework` (PSR-4)
 - **Strict types**: Always use `declare(strict_types=1);` after opening PHP tag
 - **Naming**: snake_case for methods/properties/functions (WordPress convention), PascalCase for classes
 - **Yoda conditions**: Use for all comparisons (e.g., `null === $var`)

--- a/README.mdx
+++ b/README.mdx
@@ -36,7 +36,7 @@ Ensure Action Scheduler is active (dependency is declared).
 
 ```php
 // Initialize the framework
-\Citation\WP_Webhook_Framework\Service_Provider::register();
+\juvo\WP_Webhook_Framework\Service_Provider::register();
 ```
 
 See [Configuration](./docs/configuration.mdx) for detailed configuration options.
@@ -48,7 +48,7 @@ See [Configuration](./docs/configuration.mdx) for detailed configuration options
 No webhooks are active by default. Register what you need via the action:
 
 ```php
-use Citation\WP_Webhook_Framework\Webhooks\Post_Webhook;
+use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
 
 add_action('wpwf_register_webhooks', function ($registry) {
     $post = new Post_Webhook();

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Citation\\WP_Webhook_Framework\\": "src/"
+      "juvo\\WP_Webhook_Framework\\": "src/"
     }
   },
   "archive": {

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -31,8 +31,8 @@ The `Meta_Webhook` supports three emission modes via `emission_mode()` and the `
 | `Meta_Emission_Mode::ENTITY` | Only emit the parent entity update | No |
 
 ```php
-use Citation\WP_Webhook_Framework\Webhooks\Meta_Emission_Mode;
-use Citation\WP_Webhook_Framework\Webhooks\Meta_Webhook;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Emission_Mode;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Webhook;
 
 $registry = Service_Provider::get_registry();
 
@@ -64,9 +64,9 @@ Register webhooks via the `wpwf_register_webhooks` action. No webhooks are
 active by default -- only those you explicitly register:
 
 ```php
-use Citation\WP_Webhook_Framework\Webhooks\Post_Webhook;
-use Citation\WP_Webhook_Framework\Webhooks\Meta_Emission_Mode;
-use Citation\WP_Webhook_Framework\Webhooks\Meta_Webhook;
+use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Emission_Mode;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Webhook;
 
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
     $post = new Post_Webhook();
@@ -132,13 +132,13 @@ Each instance has its own URL, retry policy, timeout, and failure tracking:
 ```php
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
     // Analytics endpoint - fast timeout, no retries
-    $analytics = new \Citation\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_analytics' );
+    $analytics = new \juvo\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_analytics' );
     $analytics->webhook_url( 'https://analytics.example.com/posts' )
               ->timeout( 10 );
     $registry->register( $analytics );
 
     // CRM endpoint - generous timeout, retries enabled
-    $crm = new \Citation\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_crm' );
+    $crm = new \juvo\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_crm' );
     $crm->webhook_url( 'https://crm.example.com/webhook' )
         ->max_retries( 5 )
         ->timeout( 60 )

--- a/docs/custom-webhooks.mdx
+++ b/docs/custom-webhooks.mdx
@@ -12,7 +12,7 @@ Create custom webhook implementations using the registry pattern.
 Extend the abstract `Webhook` class and implement `init()`:
 
 ```php
-class Custom_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
+class Custom_Webhook extends \juvo\WP_Webhook_Framework\Webhook {
     
     public function __construct() {
         parent::__construct( 'my_custom_webhook' );
@@ -63,7 +63,7 @@ See [Configuration](./configuration.mdx) for detailed options.
 ### WooCommerce Orders
 
 ```php
-class WooCommerce_Order_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
+class WooCommerce_Order_Webhook extends \juvo\WP_Webhook_Framework\Webhook {
     
     public function __construct() {
         parent::__construct( 'woocommerce_orders' );
@@ -98,7 +98,7 @@ class WooCommerce_Order_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
 ### Contact Form 7
 
 ```php
-class CF7_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
+class CF7_Webhook extends \juvo\WP_Webhook_Framework\Webhook {
     
     public function __construct() {
         parent::__construct( 'cf7_submissions' );
@@ -126,7 +126,7 @@ class CF7_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
 ### Gravity Forms
 
 ```php
-class Gravity_Forms_Webhook extends \Citation\WP_Webhook_Framework\Webhook {
+class Gravity_Forms_Webhook extends \juvo\WP_Webhook_Framework\Webhook {
     
     public function __construct() {
         parent::__construct( 'gravity_forms' );
@@ -153,7 +153,7 @@ Each instance has its own URL, retry policy, timeout, and failure tracking:
 
 ```php
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
-    $analytics = new \Citation\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_analytics' );
+    $analytics = new \juvo\WP_Webhook_Framework\Webhooks\Post_Webhook( 'post_analytics' );
     $analytics->webhook_url( 'https://analytics.example.com/posts' )
               ->timeout( 10 );
     $registry->register( $analytics );

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -2,10 +2,10 @@
 /**
  * Webhook dispatcher class.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
-namespace Citation\WP_Webhook_Framework;
+namespace juvo\WP_Webhook_Framework;
 
 use ActionScheduler_Store;
 use WP_Exception;

--- a/src/Entities/Entity_Handler.php
+++ b/src/Entities/Entity_Handler.php
@@ -2,12 +2,12 @@
 /**
  * Abstract base class for entity handlers.
  *
- * @package Citation\WP_Webhook_Framework\Entities
+ * @package juvo\WP_Webhook_Framework\Entities
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Entities;
+namespace juvo\WP_Webhook_Framework\Entities;
 
 /**
  * Abstract base class for entity handlers.

--- a/src/Entities/Meta.php
+++ b/src/Entities/Meta.php
@@ -2,10 +2,10 @@
 /**
  * Meta entity handler for handling meta-related webhook events.
  *
- * @package Citation\WP_Webhook_Framework\Entities
+ * @package juvo\WP_Webhook_Framework\Entities
  */
 
-namespace Citation\WP_Webhook_Framework\Entities;
+namespace juvo\WP_Webhook_Framework\Entities;
 
 /**
  * Meta entity handler.

--- a/src/Entities/Post.php
+++ b/src/Entities/Post.php
@@ -2,10 +2,10 @@
 /**
  * Post entity handler for handling post-related webhook events.
  *
- * @package Citation\WP_Webhook_Framework\Entities
+ * @package juvo\WP_Webhook_Framework\Entities
  */
 
-namespace Citation\WP_Webhook_Framework\Entities;
+namespace juvo\WP_Webhook_Framework\Entities;
 
 /**
  * Post entity handler.

--- a/src/Entities/Term.php
+++ b/src/Entities/Term.php
@@ -2,10 +2,10 @@
 /**
  * Term entity handler for handling term-related webhook events.
  *
- * @package Citation\WP_Webhook_Framework\Entities
+ * @package juvo\WP_Webhook_Framework\Entities
  */
 
-namespace Citation\WP_Webhook_Framework\Entities;
+namespace juvo\WP_Webhook_Framework\Entities;
 
 use WP_Term;
 

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -2,10 +2,10 @@
 /**
  * User entity handler for handling user-related webhook events.
  *
- * @package Citation\WP_Webhook_Framework\Entities
+ * @package juvo\WP_Webhook_Framework\Entities
  */
 
-namespace Citation\WP_Webhook_Framework\Entities;
+namespace juvo\WP_Webhook_Framework\Entities;
 
 /**
  * User entity handler.

--- a/src/Failure.php
+++ b/src/Failure.php
@@ -2,10 +2,10 @@
 /**
  * Data Transfer Object for webhook failure data.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
-namespace Citation\WP_Webhook_Framework;
+namespace juvo\WP_Webhook_Framework;
 
 /**
  * Data Transfer Object for webhook failure data.

--- a/src/Notifications/Blocked.php
+++ b/src/Notifications/Blocked.php
@@ -2,12 +2,12 @@
 /**
  * Failure notification handler.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
-namespace Citation\WP_Webhook_Framework\Notifications;
+namespace juvo\WP_Webhook_Framework\Notifications;
 
-use Citation\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Webhook;
 
 /**
  * Sends email notifications when webhooks fail after reaching threshold.

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -2,14 +2,14 @@
 /**
  * Abstract base class for webhook notifications.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Notifications;
+namespace juvo\WP_Webhook_Framework\Notifications;
 
-use Citation\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Webhook;
 
 /**
  * Base notification handler class.

--- a/src/Notifications/Notification_Registry.php
+++ b/src/Notifications/Notification_Registry.php
@@ -2,12 +2,12 @@
 /**
  * Notification registry for managing webhook notification handlers.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Notifications;
+namespace juvo\WP_Webhook_Framework\Notifications;
 
 /**
  * Registry for notification handlers.

--- a/src/Service_Provider.php
+++ b/src/Service_Provider.php
@@ -2,15 +2,15 @@
 /**
  * Service_Provider class for the WP Webhook Framework.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework;
+namespace juvo\WP_Webhook_Framework;
 
-use Citation\WP_Webhook_Framework\Notifications\Blocked;
-use Citation\WP_Webhook_Framework\Notifications\Notification_Registry;
+use juvo\WP_Webhook_Framework\Notifications\Blocked;
+use juvo\WP_Webhook_Framework\Notifications\Notification_Registry;
 
 /**
  * Bootstraps the framework by wiring up the Dispatcher, Registry, and

--- a/src/Support/AcfUtil.php
+++ b/src/Support/AcfUtil.php
@@ -2,12 +2,12 @@
 /**
  * Utility class for parsing ACF object IDs.
  *
- * @package Citation\WP_Webhook_Framework\Support
+ * @package juvo\WP_Webhook_Framework\Support
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Support;
+namespace juvo\WP_Webhook_Framework\Support;
 
 /**
  * Parses ACF object IDs into entity + numeric id.

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -2,12 +2,12 @@
 /**
  * Base webhook class with configuration methods.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework;
+namespace juvo\WP_Webhook_Framework;
 
 /**
  * Base webhook class with configuration capabilities.

--- a/src/Webhook_Registry.php
+++ b/src/Webhook_Registry.php
@@ -2,12 +2,12 @@
 /**
  * Webhook registry for managing webhook instances.
  *
- * @package Citation\WP_Webhook_Framework
+ * @package juvo\WP_Webhook_Framework
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework;
+namespace juvo\WP_Webhook_Framework;
 
 /**
  * Registry for managing webhook instances and enabling third-party extensibility.

--- a/src/Webhooks/Meta_Emission_Mode.php
+++ b/src/Webhooks/Meta_Emission_Mode.php
@@ -4,12 +4,12 @@
  *
  * Native enum controlling which webhooks are dispatched on meta changes.
  *
- * @package Citation\WP_Webhook_Framework\Webhooks
+ * @package juvo\WP_Webhook_Framework\Webhooks
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Webhooks;
+namespace juvo\WP_Webhook_Framework\Webhooks;
 
 /**
  * Emission mode controlling which webhooks are dispatched on meta changes.

--- a/src/Webhooks/Meta_Webhook.php
+++ b/src/Webhooks/Meta_Webhook.php
@@ -2,20 +2,20 @@
 /**
  * Meta webhook implementation.
  *
- * @package Citation\WP_Webhook_Framework\Webhooks
+ * @package juvo\WP_Webhook_Framework\Webhooks
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Webhooks;
+namespace juvo\WP_Webhook_Framework\Webhooks;
 
-use Citation\WP_Webhook_Framework\Webhook;
-use Citation\WP_Webhook_Framework\Entities\Meta;
-use Citation\WP_Webhook_Framework\Entities\Post;
-use Citation\WP_Webhook_Framework\Entities\Term;
-use Citation\WP_Webhook_Framework\Entities\User;
-use Citation\WP_Webhook_Framework\Webhook_Registry;
-use Citation\WP_Webhook_Framework\Support\AcfUtil;
+use juvo\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Entities\Meta;
+use juvo\WP_Webhook_Framework\Entities\Post;
+use juvo\WP_Webhook_Framework\Entities\Term;
+use juvo\WP_Webhook_Framework\Entities\User;
+use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Support\AcfUtil;
 
 /**
  * Meta webhook implementation with configurable emission modes.

--- a/src/Webhooks/Post_Webhook.php
+++ b/src/Webhooks/Post_Webhook.php
@@ -2,15 +2,15 @@
 /**
  * Post webhook implementation.
  *
- * @package Citation\WP_Webhook_Framework\Webhooks
+ * @package juvo\WP_Webhook_Framework\Webhooks
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Webhooks;
+namespace juvo\WP_Webhook_Framework\Webhooks;
 
-use Citation\WP_Webhook_Framework\Webhook;
-use Citation\WP_Webhook_Framework\Entities\Post;
+use juvo\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Entities\Post;
 
 /**
  * Post webhook implementation with configuration capabilities.

--- a/src/Webhooks/Term_Webhook.php
+++ b/src/Webhooks/Term_Webhook.php
@@ -2,15 +2,15 @@
 /**
  * Term webhook implementation.
  *
- * @package Citation\WP_Webhook_Framework\Webhooks
+ * @package juvo\WP_Webhook_Framework\Webhooks
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Webhooks;
+namespace juvo\WP_Webhook_Framework\Webhooks;
 
-use Citation\WP_Webhook_Framework\Webhook;
-use Citation\WP_Webhook_Framework\Entities\Term;
+use juvo\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Entities\Term;
 
 /**
  * Term webhook implementation with configuration capabilities.

--- a/src/Webhooks/User_Webhook.php
+++ b/src/Webhooks/User_Webhook.php
@@ -2,15 +2,15 @@
 /**
  * User webhook implementation.
  *
- * @package Citation\WP_Webhook_Framework\Webhooks
+ * @package juvo\WP_Webhook_Framework\Webhooks
  */
 
 declare(strict_types=1);
 
-namespace Citation\WP_Webhook_Framework\Webhooks;
+namespace juvo\WP_Webhook_Framework\Webhooks;
 
-use Citation\WP_Webhook_Framework\Webhook;
-use Citation\WP_Webhook_Framework\Entities\User;
+use juvo\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Entities\User;
 
 /**
  * User webhook implementation with configuration capabilities.


### PR DESCRIPTION
This pull request updates the PHP namespace throughout the codebase and documentation from `Citation\WP_Webhook_Framework` to `juvo\WP_Webhook_Framework`. This is a comprehensive change affecting all source files, documentation, and usage examples to ensure consistency and correct autoloading.

**Namespace migration:**

* All PHP files in the `src/` directory now use the `juvo\WP_Webhook_Framework` namespace instead of `Citation\WP_Webhook_Framework`, including all sub-namespaces and `@package` annotations. [[1]](diffhunk://#diff-85f8c2cf9079b12b6f472456fafba60513af3c08efecccc070133e54b283eac0L5-R8) [[2]](diffhunk://#diff-e9a6e6ffcdbb10bcba5d11f85097f5f5cb81268583539003aaac140d22eea552L5-R10) [[3]](diffhunk://#diff-320feaaf87dc719c4dffbeaceea1aa3a199055ffcaeb082174cac4719faa46bcL5-R8) [[4]](diffhunk://#diff-3bb9b422f69c258874ef4dceb8dbc9368443d4110f3a99a5ac4bc76bfb5e3df5L5-R8) [[5]](diffhunk://#diff-3639c93a7402390a3c8bf299d4c046be82edfe93c941daf0b0b188ab8c240981L5-R8) [[6]](diffhunk://#diff-aa194b71232f096b19a8dbb07e9dbc62818579cea3f253fcb548777b0ede80e9L5-R8) [[7]](diffhunk://#diff-983f8e4b334e2ad96a2a3adb5c61f486e6bdba787459b80de43a0c295ce8eb06L5-R8) [[8]](diffhunk://#diff-1d1715723bf92f2505402b3f5835bb522e68838359b5770697f7428051477d30L5-R10) [[9]](diffhunk://#diff-34f5d0c121bc48d4c95f209890013113203dbc1466d8efe24f86ac800c058ab8L5-R12) [[10]](diffhunk://#diff-7b42b17039d4d561a70857d821e65cc03b437d1ab467f3fe5baa390ea8e622b0L5-R10) [[11]](diffhunk://#diff-2b9553d577486375274d17c2ac08fe6e133ea1452292085bade1abb9bcd12931L5-R13) [[12]](diffhunk://#diff-d342efa0d173689cab7631e4ef45c9222326aa7037c66e45a5c7e730385a8f54L5-R10) [[13]](diffhunk://#diff-7ed7e08a51abcf0217ec71739e11d15194e6d54108571c46c0efb7a6512276ceL5-R10) [[14]](diffhunk://#diff-4ef5f51c1761fd6ea7ccf6ca0fff9b518e83b958e058204d1c35dd5616218ff2L5-R10) [[15]](diffhunk://#diff-0d41c5d7f3f09cfb259164fc55b110410f9eb803393e920428a8796def744cc0L7-R12)

* The `composer.json` autoload mapping is updated to use the new namespace for PSR-4 autoloading.

**Documentation and usage updates:**

* All documentation files (`README.mdx`, `AGENTS.md`, and files in `docs/`) have been updated to reference the new namespace in code examples and instructions. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L11-R11) [[2]](diffhunk://#diff-c8f40cf7404d0d8acab7cb5d53ee718a37441b7fa1e6bee1c3ca738ce427c89aL39-R39) [[3]](diffhunk://#diff-c8f40cf7404d0d8acab7cb5d53ee718a37441b7fa1e6bee1c3ca738ce427c89aL51-R51) [[4]](diffhunk://#diff-4f38a2982a8c36e1912bd5aa33a8ddfa627d5017f5f4a1106953c479b977f2c2L34-R35) [[5]](diffhunk://#diff-4f38a2982a8c36e1912bd5aa33a8ddfa627d5017f5f4a1106953c479b977f2c2L67-R69) [[6]](diffhunk://#diff-4f38a2982a8c36e1912bd5aa33a8ddfa627d5017f5f4a1106953c479b977f2c2L135-R141) [[7]](diffhunk://#diff-7ef1d6300728401649804eebeaf8386dc3f28f8779bc7d1a20162d62bcd91efeL15-R15) [[8]](diffhunk://#diff-7ef1d6300728401649804eebeaf8386dc3f28f8779bc7d1a20162d62bcd91efeL66-R66) [[9]](diffhunk://#diff-7ef1d6300728401649804eebeaf8386dc3f28f8779bc7d1a20162d62bcd91efeL101-R101) [[10]](diffhunk://#diff-7ef1d6300728401649804eebeaf8386dc3f28f8779bc7d1a20162d62bcd91efeL129-R129) [[11]](diffhunk://#diff-7ef1d6300728401649804eebeaf8386dc3f28f8779bc7d1a20162d62bcd91efeL156-R156)

These changes ensure that the framework is correctly namespaced for the new vendor, and that all documentation and autoloading mechanisms are consistent with this update.