### PR TITLE
Expand application webhook coverage and delivery behavior

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+/.github export-ignore
+/.gitignore export-ignore
+/.phpunit.result.cache export-ignore
+/.wp-env.json export-ignore
+/AGENTS.md export-ignore
+/composer.lock export-ignore
+/docs export-ignore
+/package-lock.json export-ignore
+/package.json export-ignore
+/phpcs.xml export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,32 @@
+name: Integration Tests
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  application-tests:
+    name: wp-env Application Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run wp-env application tests
+        run: npm run test:integration
+
+      - name: Stop wp-env
+        if: ${{ always() }}
+        run: npm run wp-env:stop

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Setup PHP
         if: steps.vendor-cache.outputs.cache-hit != 'true'
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
   phpstan:
     name: PHPStan
@@ -60,10 +60,11 @@ jobs:
           coverage: none
 
       - name: Restore vendor cache
+        id: vendor-cache
         uses: actions/cache/restore@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Run PHPStan
         id: phpstan
@@ -72,7 +73,11 @@ jobs:
 
       - name: Show PHPStan results in PR
         if: ${{ always() && steps.phpstan.outcome == 'failure' }}
-        run: cs2pr ./phpstan-report.xml
+        run: test -s ./phpstan-report.xml && cs2pr ./phpstan-report.xml || true
+
+      - name: Fail on PHPStan errors
+        if: ${{ steps.phpstan.outcome == 'failure' }}
+        run: exit 1
 
   phpcs:
     name: PHPCS
@@ -91,10 +96,11 @@ jobs:
           coverage: none
 
       - name: Restore vendor cache
+        id: vendor-cache
         uses: actions/cache/restore@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Run PHPCS
         id: phpcs
@@ -103,4 +109,8 @@ jobs:
 
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: cs2pr ./phpcs-report.xml --graceful-warnings
+        run: test -s ./phpcs-report.xml && cs2pr ./phpcs-report.xml --graceful-warnings || true
+
+      - name: Fail on PHPCS errors
+        if: ${{ steps.phpcs.outcome == 'failure' }}
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 vendor/
+node_modules/
 
 # PHPStan cache
 .phpstan.cache
@@ -22,6 +23,7 @@ Thumbs.db
 composer.lock
 
 # Testing
+.phpunit.result.cache
 phpunit.xml
 tests/_output/
 tests/_support/_generated/

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,19 @@
+{
+  "core": null,
+  "phpVersion": "8.1",
+  "port": 8888,
+  "autoPort": true,
+  "testsEnvironment": false,
+  "config": {
+    "WP_DEBUG": true,
+    "SCRIPT_DEBUG": true,
+    "WP_ENVIRONMENT_TYPE": "local"
+  },
+  "plugins": [
+    "./tests/wp-env/plugins/wpwf-test-app",
+    "./tests/wp-env/plugins/wpwf-test-secondary"
+  ],
+  "mappings": {
+    "wp-content/wpwf-framework": "."
+  }
+}

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,7 +3,6 @@
   "phpVersion": "8.1",
   "port": 8888,
   "autoPort": true,
-  "testsEnvironment": false,
   "config": {
     "WP_DEBUG": true,
     "SCRIPT_DEBUG": true,
@@ -14,6 +13,7 @@
     "./tests/wp-env/plugins/wpwf-test-secondary"
   ],
   "mappings": {
-    "wp-content/wpwf-framework": "."
+    "wp-content/wpwf-framework": ".",
+    "wp-content/mu-plugins/wpwf-test-receiver.php": "./tests/wp-env/mu-plugins/wpwf-test-receiver.php"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 ## Commands
 - `composer install` - Install dependencies
+- `npm install` - Install wp-env tooling
+- `npm run wp-env:start` - Start the local WordPress test environment
+- `npm run test:phpunit` - Run the wp-env application test suite
+- `npm run wp-env:stop` - Stop the local WordPress test environment
 - `composer run-script phpstan` - Run static analysis (PHPStan level 6)
 - `composer run-script phpcs` - Lint code (WordPress coding standards)
 - `composer run-script phpcbf` - Auto-fix code style issues
@@ -18,7 +22,7 @@
 - **Type hints**: Use strict PHP 8.0 types + PHPStan types for precision
 - **Error handling**: Direct exception throwing in Action Scheduler context; use `wp_trigger_error()` elsewhere
 - **Dependencies**: Uses WooCommerce Action Scheduler 3.7+ for async webhooks
-- **Testing**: No test suite currently configured
+- **Testing**: wp-env application tests with fixture plugins that each bootstrap the shared framework
 
 ## Architecture
 Entity-based webhook framework using registry pattern. Webhooks extend abstract `Webhook` class, implement `init()` method, and register via `Service_Provider`.
@@ -63,3 +67,4 @@ Add new docs with an "@" mention to the "AGENTS.md" including a quick explanatio
 - @docs/notifications.mdx - Notification system, opt-in pattern, custom handlers
 - @docs/webhook-statefulness.mdx - Webhook statefulness rules and best practices
 - @docs/failure-handling.mdx - Failure monitoring, retry mechanism, blocking behavior
+- @docs/testing.mdx - wp-env application test setup, fixture plugins, and local test commands

--- a/README.mdx
+++ b/README.mdx
@@ -6,6 +6,7 @@ description: Entity-level webhooks for WordPress using Action Scheduler. Sends n
 # WP Webhook Framework
 
 [![Quality Check](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/quality-check.yml/badge.svg)](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/quality-check.yml)
+[![Integration Tests](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/integration-tests.yml)
 
 Entity-level webhooks for WordPress using Action Scheduler. Sends non-blocking POSTs for create/update/delete of posts, terms, and users. Meta changes trigger the entity update. ACF updates include field context. Features intelligent failure monitoring with email notifications, automatic blocking, and comprehensive filtering options.
 
@@ -39,6 +40,8 @@ Ensure Action Scheduler is active (dependency is declared).
 // Initialize the framework
 \juvo\WP_Webhook_Framework\Service_Provider::register();
 ```
+
+`Service_Provider::register()` is idempotent, so separate plugins can call it independently while sharing the same library checkout.
 
 :::tip
 If you are using a prefixer make sure to exclude this library. Due the strong typings used it will break plugins
@@ -145,6 +148,11 @@ See [Failure Handling](./docs/failure-handling.mdx) for configuration and custom
 
 ```bash
 composer install              # Install dependencies
+npm install                   # Install wp-env tooling
+npm run wp-env:start          # Start WordPress test environment
+npm run composer:install      # Install Composer dependencies inside wp-env
+npm run test:phpunit          # Run application tests
+npm run wp-env:stop           # Stop WordPress test environment
 composer run-script phpstan   # Run static analysis
 composer run-script phpcs     # Lint code
 composer run-script phpcbf    # Auto-fix code style
@@ -157,4 +165,5 @@ composer run-script phpcbf    # Auto-fix code style
 - [Hooks and Filters](./docs/hooks-and-filters.mdx) - All available hooks and filters with examples
 - [Failure Handling](./docs/failure-handling.mdx) - Failure monitoring, retry mechanism, and blocking behavior
 - [Notifications](./docs/notifications.mdx) - Notification system, opt-in pattern, and custom handlers
+- [Testing](./docs/testing.mdx) - wp-env application test suite, fixture plugins, and validation workflow
 - [Webhook Statefulness](./docs/webhook-statefulness.mdx) - Webhook statelessness rules and best practices

--- a/README.mdx
+++ b/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: WP Webhook Framework
-description: Entity-level webhooks for WordPress using Action Scheduler. Sends non-blocking POSTs for create/update/delete of posts, terms, and users.
+description: Entity-level webhooks for WordPress with scheduled and immediate delivery modes, retries, and failure monitoring.
 ---
 
 # WP Webhook Framework
@@ -8,11 +8,12 @@ description: Entity-level webhooks for WordPress using Action Scheduler. Sends n
 [![Quality Check](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/quality-check.yml/badge.svg)](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/quality-check.yml)
 [![Integration Tests](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/integration-tests.yml)
 
-Entity-level webhooks for WordPress using Action Scheduler. Sends non-blocking POSTs for create/update/delete of posts, terms, and users. Meta changes trigger the entity update. ACF updates include field context. Features intelligent failure monitoring with email notifications, automatic blocking, and comprehensive filtering options.
+Entity-level webhooks for WordPress using Action Scheduler with optional immediate delivery mode. Sends POSTs for create/update/delete of posts, terms, and users. Meta changes trigger the entity update. ACF updates include field context. Features intelligent failure monitoring with email notifications, automatic blocking, and comprehensive filtering options.
 
 ## Features
 
-- **Action Scheduler dispatch** - 5s delay, non-blocking async delivery
+- **Delivery mode control** - Choose scheduled async delivery (default) or immediate synchronous first attempt
+- **Action Scheduler dispatch** - 5s delay for queued webhooks with deduplication
 - **Automatic deduplication** - Dispatcher-level on action+entity+id and meta-level per-request dedup for plugin hooks (ACF, Meta Box, etc.)
 - **Entity-aware delivery payloads** - Derives post_type, taxonomy, and roles at send time
 - **Send-time enrichment** - Adds REST URLs when available
@@ -69,6 +70,23 @@ add_action('wpwf_register_webhooks', function ($registry) {
 
 See [Configuration](./docs/configuration.mdx) for registry configuration and [Custom Webhooks](./docs/custom-webhooks.mdx) for creating your own webhooks.
 
+### Immediate Delivery Mode
+
+```php
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
+
+add_action('wpwf_register_webhooks', function ($registry) {
+    $post = new Post_Webhook();
+    $post->webhook_url('https://api.example.com/posts')
+         ->delivery_mode(Delivery_Mode::IMMEDIATE)
+         ->max_retries(2);
+    $registry->register($post);
+});
+```
+
+Immediate mode sends the first attempt in the current request. If it fails, retries are still queued asynchronously with exponential backoff.
+
 ### Filter Payloads
 
 ```php
@@ -95,7 +113,9 @@ See [Hooks and Filters](./docs/hooks-and-filters.mdx) for all available hooks an
 
 **Data Flow:**
 ```
-WordPress hook → Webhook → Handler::prepare_payload() → Webhook::emit() → Dispatcher → Action Scheduler → Dispatcher::process_scheduled_webhook() → Handler::prepare_delivery_payload() → HTTP POST
+WordPress hook → Webhook → Handler::prepare_payload() → Webhook::emit() → Dispatcher
+  ├─ scheduled mode: queue in Action Scheduler → process_scheduled_webhook() → HTTP POST
+  └─ immediate mode: send now in current request → HTTP POST
 ```
 
 ### Webhook Statefulness

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "juvo/wp-webhook-framework",
+  "name": "citation-media/wp-webhook-framework",
   "description": "Entity-level webhook framework for WordPress using Action Scheduler.",
   "type": "library",
   "license": "GPL-2.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,20 @@
   },
   "archive": {
     "exclude": [
-      "/docs",
       "/.github",
+      "/.gitattributes",
+      "/.gitignore",
+      "/.phpunit.result.cache",
+      "/.wp-env.json",
+      "/AGENTS.md",
+      "/composer.lock",
+      "/docs",
+      "/package-lock.json",
+      "/package.json",
       "/phpcs.xml",
       "/phpstan.neon",
-      "/AGENTS.md"
+      "/phpunit.xml.dist",
+      "/tests"
     ]
   },
   "scripts": {
@@ -42,14 +51,20 @@
   },
   "require-dev": {
     "composer/installers": "^v2",
+    "doctrine/instantiator": "^1.5",
+    "phpunit/phpunit": "^9.6",
     "phpstan/phpstan": "^2.1.2",
     "php-stubs/acf-pro-stubs": "^6",
     "szepeviktor/phpstan-wordpress": "^v2.0.1",
     "phpstan/extension-installer": "^1.1",
     "php-stubs/wp-cli-stubs": "^2",
+    "yoast/phpunit-polyfills": "^4.0",
     "wp-coding-standards/wpcs": "^3.1.0"
   },
   "config": {
+    "platform": {
+      "php": "8.1.0"
+    },
     "allow-plugins": {
       "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a69a67eca31f8573ce21c427e4b1276",
+    "content-hash": "8e884880e6eb5d14ce91fef02a63b6e7",
     "packages": [
         {
             "name": "woocommerce/action-scheduler",
@@ -292,6 +292,312 @@
                 }
             ],
             "time": "2025-07-17T20:45:56+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "php-stubs/acf-pro-stubs",
@@ -722,6 +1028,1447 @@
             "time": "2025-08-04T19:17:37+00:00"
         },
         {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.13.2",
             "source": {
@@ -868,6 +2615,56 @@
             "time": "2025-02-12T18:43:37+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
             "name": "wp-coding-standards/wpcs",
             "version": "3.2.0",
             "source": {
@@ -932,6 +2729,69 @@
                 }
             ],
             "time": "2025-07-24T20:08:31+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],
@@ -940,8 +2800,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform-overrides": {
+        "php": "8.1.0"
+    },
+    "plugin-api-version": "2.9.0"
 }

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -14,11 +14,33 @@ Configure individual webhooks using chainable methods.
 | Method | Description | Default |
 |--------|-------------|---------|
 | `webhook_url(string)` | Custom endpoint URL | None |
+| `delivery_mode(Delivery_Mode)` | Delivery strategy (`SCHEDULED` or `IMMEDIATE`) | `Delivery_Mode::SCHEDULED` |
 | `max_consecutive_failures(int)` | Failures before blocking (0 disables) | 10 |
 | `max_retries(int)` | Retry attempts per failed event | 0 |
 | `timeout(int)` | HTTP timeout in seconds (1-300) | 30 |
 | `headers(array)` | Custom HTTP headers | [] |
 | `notifications(array)` | Enable notification handlers | [] |
+
+### Delivery Modes
+
+The base `Webhook` class supports two delivery modes through `delivery_mode()` and the `Delivery_Mode` enum:
+
+| Enum case | Behavior | Default |
+|----------|----------|---------|
+| `Delivery_Mode::SCHEDULED` | Queue delivery in Action Scheduler with deduplication | **Yes** |
+| `Delivery_Mode::IMMEDIATE` | Send first attempt in the current request | No |
+
+```php
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
+
+$post = new Post_Webhook();
+$post->webhook_url( 'https://api.example.com/posts' )
+     ->delivery_mode( Delivery_Mode::IMMEDIATE )
+     ->max_retries( 2 );
+```
+
+When `Delivery_Mode::IMMEDIATE` fails, retries still run through Action Scheduler using the configured backoff logic.
 
 ### Meta Emission Modes
 
@@ -51,6 +73,7 @@ so rapid meta changes on the same post collapse into a single delivery.
 
 ```php
 $webhook->webhook_url( 'https://api.example.com' )
+        ->delivery_mode( Delivery_Mode::SCHEDULED )
         ->max_consecutive_failures( 5 )
         ->max_retries( 3 )
         ->timeout( 60 )

--- a/docs/custom-webhooks.mdx
+++ b/docs/custom-webhooks.mdx
@@ -18,6 +18,7 @@ class Custom_Webhook extends \juvo\WP_Webhook_Framework\Webhook {
         parent::__construct( 'my_custom_webhook' );
         
         $this->max_retries( 3 )
+             ->delivery_mode( \juvo\WP_Webhook_Framework\Delivery_Mode::SCHEDULED )
              ->max_consecutive_failures( 5 )
              ->timeout( 30 )
              ->webhook_url( 'https://api.example.com/custom' )
@@ -49,6 +50,7 @@ add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): v
 
 | Method | Description | Default |
 |--------|-------------|---------|
+| `delivery_mode(Delivery_Mode)` | Delivery strategy (`SCHEDULED` or `IMMEDIATE`) | `Delivery_Mode::SCHEDULED` |
 | `max_retries(int)` | Retry attempts per failed event | 0 |
 | `max_consecutive_failures(int)` | Failures before blocking (0 disables) | 10 |
 | `timeout(int)` | HTTP timeout in seconds (1-300) | 30 |
@@ -218,4 +220,5 @@ See [Webhook Statefulness](./webhook-statefulness.mdx) for details.
 2. **Check plugin existence** before registering integration webhooks
 3. **Keep webhooks stateless** - pass data to `emit()`, don't store on instance
 4. **Use meaningful names** - lowercase with underscores
-5. **Set appropriate timeouts** - consider endpoint response times
+5. **Set delivery mode intentionally** - use `IMMEDIATE` only when same-request delivery is required
+6. **Set appropriate timeouts** - consider endpoint response times

--- a/docs/failure-handling.mdx
+++ b/docs/failure-handling.mdx
@@ -18,6 +18,8 @@ For email notifications and custom handlers, see [Notifications](./notifications
 
 **Retry**: Framework automatically retries a single failed webhook event (e.g., "Post #123 update") with exponential backoff.
 
+In `Delivery_Mode::IMMEDIATE`, the first attempt runs in the current request and failed retries are still queued in Action Scheduler.
+
 **Blocking**: Stops all webhooks to a URL after multiple distinct events have failed, preventing resource waste on dead endpoints.
 
 ## Retry Mechanism
@@ -61,7 +63,7 @@ add_filter( 'wpwf_retry_base_time', function ( int $base, string $name, int $cou
 1. **Webhook fails** → Retries attempted according to `max_retries()`
 2. **All retries fail** → Failure count incremented for URL
 3. **Threshold reached** → URL blocked, `wpwf_webhook_blocked` action fired
-4. **Success** → Counter reset, URL unblocked
+4. **Success or expired block window** → Counter reset, URL unblocked
 
 ### Configuration
 
@@ -89,7 +91,7 @@ array(
 )
 ```
 
-**Expiration:** 1 hour (auto-unblock)
+**Expiration:** 1 hour. When a blocked URL is checked after that window, the framework starts a fresh failure window instead of carrying the old failure count forward.
 
 ## Webhook Status Actions
 
@@ -115,6 +117,7 @@ For detailed action documentation, see [Hooks and Filters](./hooks-and-filters.m
 **Files:** `src/Dispatcher.php`, `src/Failure.php`, `src/Webhook.php`
 
 **Key methods:**
+- `Dispatcher::dispatch_immediately()` - Sends immediate first attempt and queues retries on failure
 - `Dispatcher::schedule_retry_if_applicable()` - Schedules retry with backoff
 - `Webhook::calculate_retry_delay()` - Calculates exponential delay
 - `Dispatcher::trigger_webhook_failure()` - Tracks failures, fires actions

--- a/docs/hooks-and-filters.mdx
+++ b/docs/hooks-and-filters.mdx
@@ -207,25 +207,28 @@ add_filter( 'wpwf_headers', function ( array $headers, string $entity, int|strin
 Exclude specific meta keys from triggering webhooks.
 
 **Parameters:**
-- `$excluded_keys` (array<int,string>) - Meta keys to exclude
+- `$excluded` (bool) - Whether the current key should be excluded
 - `$meta_key` (string) - The current meta key
 - `$meta_type` (string) - The meta type (post, term, user)
 - `$object_id` (int) - The object ID
 
-**Returns:** array<int,string>
+**Returns:** bool
 
-**Default excluded:** `_edit_lock`, `_edit_last`, `_acf_changed`, `_acf_cache_*`
+**Default excluded:** `_edit_lock`, `_edit_last`, `session_tokens`, and any meta key starting with `_`
 
 ```php
-add_filter( 'wpwf_excluded_meta', function ( array $excluded_keys, string $meta_key, string $meta_type, int $object_id ): array {
-    $excluded_keys[] = '_my_internal_field';
-    return $excluded_keys;
+add_filter( 'wpwf_excluded_meta', function ( bool $excluded, string $meta_key, string $meta_type, int $object_id ): bool {
+    if ( '_my_internal_field' === $meta_key ) {
+        return true;
+    }
+
+    return $excluded;
 }, 10, 4 );
 ```
 
-### `wpwf_failure_notification_email`
+### `wpwf_blocked_notification_email`
 
-Filter failure notification email data. Return `false` to prevent email.
+Filter blocked notification email data. Return `false` to prevent email.
 
 **Parameters:**
 - `$email_data` (array{recipient: string, subject: string, message: string, headers: array, url: string, error_message: string, response: mixed})
@@ -236,13 +239,13 @@ Filter failure notification email data. Return `false` to prevent email.
 
 ```php
 // Custom recipient
-add_filter( 'wpwf_failure_notification_email', function ( array $email_data, string $url, mixed $response ): array {
+ add_filter( 'wpwf_blocked_notification_email', function ( array $email_data, string $url, mixed $response ): array {
     $email_data['recipient'] = 'webhooks@example.com';
     return $email_data;
 }, 10, 3 );
 
 // Disable email notifications
-add_filter( 'wpwf_failure_notification_email', fn() => false );
+ add_filter( 'wpwf_blocked_notification_email', fn() => false );
 ```
 
 ### `wpwf_max_consecutive_failures`
@@ -274,6 +277,28 @@ Filter webhook request timeout in seconds.
 ```php
 add_filter( 'wpwf_timeout', function ( int $timeout, string $webhook_name ): int {
     return 'bulk_sync_webhook' === $webhook_name ? 120 : $timeout;
+}, 10, 2 );
+```
+
+### `wpwf_delivery_mode`
+
+Filter the webhook delivery mode.
+
+**Parameters:**
+- `$delivery_mode` (string) - The configured mode value (`scheduled` or `immediate`)
+- `$webhook_name` (string) - The webhook name
+
+**Returns:** string
+
+```php
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+
+add_filter( 'wpwf_delivery_mode', function ( string $delivery_mode, string $webhook_name ): string {
+    if ( 'critical_webhook' !== $webhook_name ) {
+        return $delivery_mode;
+    }
+
+    return Delivery_Mode::IMMEDIATE->value;
 }, 10, 2 );
 ```
 
@@ -331,8 +356,9 @@ Example payload (post):
 
 Filters are applied in this order:
 
-1. `wpwf_payload` - Modify or prevent payload
+1. `wpwf_delivery_mode` - Resolve scheduled vs immediate mode
 2. `wpwf_url` - Customize webhook URL
-3. `wpwf_request_body` - Modify final request body before send
-4. `wpwf_headers` - Customize HTTP headers
-5. `wpwf_excluded_meta` - Filter meta keys (meta webhooks only)
+3. `wpwf_payload` - Modify or prevent payload
+4. `wpwf_request_body` - Modify final request body before send
+5. `wpwf_headers` - Customize HTTP headers
+6. `wpwf_excluded_meta` - Filter meta keys (meta webhooks only)

--- a/docs/notifications.mdx
+++ b/docs/notifications.mdx
@@ -25,10 +25,11 @@ Each handler:
 
 ```php
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
-    $post_webhook = $registry->get( 'post' );
-    if ( null !== $post_webhook ) {
-        $post_webhook->notifications( array( 'blocked' ) );
-    }
+    $post_webhook = new \juvo\WP_Webhook_Framework\Webhooks\Post_Webhook();
+    $post_webhook->webhook_url( 'https://api.example.com/posts' )
+                 ->notifications( array( 'blocked' ) );
+
+    $registry->register( $post_webhook );
 } );
 ```
 
@@ -97,10 +98,11 @@ add_action( 'wpwf_register_notifications', function ( Notification_Registry $reg
 
 ```php
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
-    $webhook = $registry->get( 'post' );
-    if ( null !== $webhook ) {
-        $webhook->notifications( array( 'blocked', 'slack' ) );
-    }
+    $webhook = new \juvo\WP_Webhook_Framework\Webhooks\Post_Webhook();
+    $webhook->webhook_url( 'https://api.example.com/posts' )
+            ->notifications( array( 'blocked', 'slack' ) );
+
+    $registry->register( $webhook );
 } );
 ```
 
@@ -131,10 +133,8 @@ add_action( 'wpwf_register_notifications', function ( Notification_Registry $reg
 
 ```php
 add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
-    $webhook = $registry->get( 'post' );
-    if ( null === $webhook ) {
-        return;
-    }
+    $webhook = new \juvo\WP_Webhook_Framework\Webhooks\Post_Webhook();
+    $webhook->webhook_url( 'https://api.example.com/posts' );
 
     $notifications = array( 'blocked' );
     if ( 'production' === wp_get_environment_type() ) {
@@ -142,6 +142,7 @@ add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): v
     }
     
     $webhook->notifications( $notifications );
+    $registry->register( $webhook );
 } );
 ```
 

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -1,0 +1,50 @@
+---
+title: Testing
+description: Run wp-env application tests against a real WordPress install with fixture plugins that bootstrap the framework themselves.
+sidebar:
+  order: 7
+---
+
+Use the bundled `wp-env` application test setup to validate how the framework behaves inside WordPress.
+
+The suite runs against the development site mounted by `.wp-env.json`, while PHPUnit uses the WordPress core test bootstrap inside that container.
+
+## What the suite covers
+
+- `wp-env` mounts the primary and secondary fixtures as normal plugins and activates both of them on the development site.
+- Each fixture plugin loads the shared library from the repository checkout, loads Action Scheduler, and calls `Service_Provider::register()` on its own.
+- `tests/phpunit/bootstrap.php` loads those same plugin entrypoints for the WordPress core test bootstrap, because that bootstrap uses its own isolated install state.
+- The primary fixture consumer registers built-in post, term, user, and custom webhooks.
+- The secondary fixture consumer registers its own post webhook to validate multi-plugin usage.
+- PHPUnit tests execute scheduled Action Scheduler jobs and assert the final request payloads.
+- The GitHub Actions workflow runs the same suite on every push and pull request.
+
+## Commands
+
+```bash
+npm install
+npm run wp-env:start
+npm run composer:install
+npm run test:phpunit
+npm run wp-env:stop
+```
+
+## Key files
+
+- `.wp-env.json` mounts the repository checkout and activates both fixture plugins.
+- `tests/phpunit/bootstrap.php` loads both plugin entrypoints into the WordPress core PHPUnit bootstrap.
+- `tests/wp-env/plugins/wpwf-test-app/wpwf-test-app.php` boots the shared framework from the primary plugin and defines its fixture hooks.
+- `tests/wp-env/plugins/wpwf-test-secondary/wpwf-test-secondary.php` boots the shared framework from the secondary plugin and defines its fixture hooks.
+- `tests/phpunit/includes/class-wpwf-webhook-test-case.php` provides helpers for capturing requests and executing queued actions.
+- `tests/phpunit/PostWebhookCrudTest.php`, `tests/phpunit/TermWebhookCrudTest.php`, and `tests/phpunit/UserWebhookCrudTest.php` provide separate CRUD examples per entity.
+- `.github/workflows/integration-tests.yml` runs the suite in CI.
+
+## Extending the suite
+
+Add new application tests under `tests/phpunit`. Reuse `WPWF_Webhook_Test_Case` when you need to:
+
+- inspect pending `wpwf_send_webhook` actions
+- execute scheduled actions immediately
+- assert the final HTTP request body and headers
+
+This keeps future validation tests focused on webhook behaviour instead of environment setup.

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -11,12 +11,12 @@ The suite runs against the development site mounted by `.wp-env.json`, while PHP
 
 ## What the suite covers
 
-- `wp-env` mounts the primary and secondary fixtures as normal plugins and activates both of them on the development site.
+- `wp-env` mounts the primary and secondary fixture plugins plus a receiver MU plugin used to capture real HTTP webhook deliveries.
 - Each fixture plugin loads the shared library from the repository checkout, loads Action Scheduler, and calls `Service_Provider::register()` on its own.
-- `tests/phpunit/bootstrap.php` loads those same plugin entrypoints for the WordPress core test bootstrap, because that bootstrap uses its own isolated install state.
+- `tests/phpunit/bootstrap.php` loads the same fixture plugin entrypoints for the WordPress core test bootstrap, because that bootstrap uses its own isolated install state.
 - The primary fixture consumer registers built-in post, term, user, and custom webhooks.
 - The secondary fixture consumer registers its own post webhook to validate multi-plugin usage.
-- PHPUnit tests execute scheduled Action Scheduler jobs and assert the final request payloads.
+- PHPUnit tests execute scheduled Action Scheduler jobs, call real HTTP receiver endpoints, and assert persisted delivery logs.
 - The GitHub Actions workflow runs the same suite on every push and pull request.
 
 ## Commands
@@ -31,12 +31,18 @@ npm run wp-env:stop
 
 ## Key files
 
-- `.wp-env.json` mounts the repository checkout and activates both fixture plugins.
-- `tests/phpunit/bootstrap.php` loads both plugin entrypoints into the WordPress core PHPUnit bootstrap.
+- `.wp-env.json` mounts the repository checkout and maps the receiver MU plugin.
+- `tests/phpunit/bootstrap.php` loads fixture plugin entrypoints into the WordPress core PHPUnit bootstrap.
+- `tests/wp-env/mu-plugins/wpwf-test-receiver.php` handles incoming webhook HTTP requests and exposes log/reset endpoints for assertions.
 - `tests/wp-env/plugins/wpwf-test-app/wpwf-test-app.php` boots the shared framework from the primary plugin and defines its fixture hooks.
 - `tests/wp-env/plugins/wpwf-test-secondary/wpwf-test-secondary.php` boots the shared framework from the secondary plugin and defines its fixture hooks.
-- `tests/phpunit/includes/class-wpwf-webhook-test-case.php` provides helpers for capturing requests and executing queued actions.
+- `tests/phpunit/includes/class-wpwf-webhook-test-case.php` provides helpers for receiver log management and queued action execution.
 - `tests/phpunit/PostWebhookCrudTest.php`, `tests/phpunit/TermWebhookCrudTest.php`, and `tests/phpunit/UserWebhookCrudTest.php` provide separate CRUD examples per entity.
+- `tests/phpunit/MetaWebhookTest.php` covers meta emission modes, parent entity updates, and delivery payload enrichment.
+- `tests/phpunit/DeliveryModeTest.php` covers scheduled vs immediate dispatch behavior.
+- `tests/phpunit/WebhookFilterTest.php` covers runtime filters for delivery mode, URL routing, payload suppression, headers, and request body changes.
+- `tests/phpunit/WebhookFailureHandlingTest.php` covers retries, backoff scheduling metadata, and URL blocking behavior.
+- `tests/phpunit/NotificationAndFailureStateTest.php` covers blocked email notifications and expired-block recovery.
 - `.github/workflows/integration-tests.yml` runs the suite in CI.
 
 ## Extending the suite
@@ -45,6 +51,6 @@ Add new application tests under `tests/phpunit`. Reuse `WPWF_Webhook_Test_Case` 
 
 - inspect pending `wpwf_send_webhook` actions
 - execute scheduled actions immediately
-- assert the final HTTP request body and headers
+- assert receiver log entries (URL, headers, payload, webhook name)
 
 This keeps future validation tests focused on webhook behaviour instead of environment setup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4669 @@
+{
+  "name": "wp-webhook-framework",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wp-webhook-framework",
+      "devDependencies": {
+        "@wordpress/env": "11.1.0"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
+    "node_modules/@octokit/app": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
+      "integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-app": "^6.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/types": "^12.0.0",
+        "@octokit/webhooks": "^12.0.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+      "integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.1.0",
+        "@octokit/auth-oauth-user": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+        "universal-github-app-jwt": "^1.1.2",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+      "integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.1.0",
+        "@octokit/auth-oauth-user": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+      "integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/oauth-methods": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+      "integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.1.0",
+        "@octokit/oauth-methods": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+      "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+      "integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/oauth-methods": "^4.0.0",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+      "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+      "integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "btoa-lite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+      "integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
+      "integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^13.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+      "integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^12.2.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+      "integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/webhooks-methods": "^4.1.0",
+        "@octokit/webhooks-types": "7.6.1",
+        "aggregate-error": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+      "integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/webhooks-types": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+      "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
+      "dev": true
+    },
+    "node_modules/@php-wasm/cli-util": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.4.tgz",
+      "integrity": "sha512-SVJBkvwT9FMM9AhVgjIwXh1KJZaEl/IvULIXKKSfmdqhk9SLpqmyJWw/WsibDzsj1FtcUHO+MmI5t7MVi5OioA==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/util": "3.1.4",
+        "fast-xml-parser": "^5.3.4",
+        "jsonc-parser": "3.3.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/logger": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.4.tgz",
+      "integrity": "sha512-qJADSkoHZIvoLomnyglMcISdfJH+9fZ+4YZ7N/vJrfo0vHp/51nOmKa38eKmONUGInAgKHIJ5LZ9b73dYtDygA==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/node-polyfills": "3.1.4"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.4.tgz",
+      "integrity": "sha512-sDWXq+3ApKDZAVTJRaERRBkzpoiudNcnXz5yk5leeqymCOwNz6F0V+jSndcO0shEbsOTOT6b4J89pdKVSBUVOg==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/cli-util": "3.1.4",
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node-7-4": "3.1.4",
+        "@php-wasm/node-8-0": "3.1.4",
+        "@php-wasm/node-8-1": "3.1.4",
+        "@php-wasm/node-8-2": "3.1.4",
+        "@php-wasm/node-8-3": "3.1.4",
+        "@php-wasm/node-8-4": "3.1.4",
+        "@php-wasm/node-8-5": "3.1.4",
+        "@php-wasm/node-polyfills": "3.1.4",
+        "@php-wasm/universal": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "@wp-playground/common": "3.1.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.3.4",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-7-4": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.4.tgz",
+      "integrity": "sha512-iP95JNInGsJdu4Zp/7x3rROpw1bbidq9X2RDwjO6fhCrG+zWifKgg/I2hFAIpYAJeZXAaN4MPyqeihtmLZ204g==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-0": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.4.tgz",
+      "integrity": "sha512-upNChLPNE95Pq1OHsHaZn1o36r0px9Iz2gSPXE+rZO4+C93JFyG24VJAqxh61c7CN+4Y1hudee66X4zCe5BAog==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-1": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.4.tgz",
+      "integrity": "sha512-JXW3o278v4Rf02SZLxV4g/zDtDxp3KNsv+9Yy1QP7SscfDWe3R7Vo65S2NG7GZItIVcQ8n1KLMqZLCOcDR+tmg==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-2": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.4.tgz",
+      "integrity": "sha512-QRT436IfwQVLpns2dpCsgEuDAh4kS1SRHcaG3cn0ShUpUwxwU/vkGR58uKmXDPGSeLYgMX8ozLZWARUUK8TjCg==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-3": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.4.tgz",
+      "integrity": "sha512-l/xUJqKB14PLdvVQAEDYfs8Ne3vcQZ+ixOZre1k+gig6L2M0UZkX+UKf5PtE26Ft3VAquQUSeYgmPrO3A1kdnQ==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-4": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.4.tgz",
+      "integrity": "sha512-HvxShZ9RjQF+QXDlN44qcRou4okq6JTEHA3EYmqzaJv7V5+Zjn3K3bOaUAWtd9wem+kc4p1RTJ+ZgaMSp+QUVw==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-5": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.4.tgz",
+      "integrity": "sha512-dQWrrA5Wjx0mo3a5COWUjlbCSPM7k+FXJoSnJWBSFQwfQycMEPOWxrRX2Hxtm+i6QXGI5UyJR0SI9cSVIx09RA==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-polyfills": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.4.tgz",
+      "integrity": "sha512-7lL50hCUWA7cDl6Q6rWIks4eKbfI/TrDl8GKYf7E56Ep1JNUMFLmzU/nxmPDB9la+fbVhpkL17Tc5izyqK3Y1A==",
+      "dev": true
+    },
+    "node_modules/@php-wasm/progress": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.4.tgz",
+      "integrity": "sha512-eu9qyfuNJr8Jju2mIqAtP5ovt7lwbduDvjHBbrP/uHicBqCwI6uPK9dGc0qLjQ8ZQ/yJqi+qOpnpUKbk0xIWOw==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node-polyfills": "3.1.4"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/scopes": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.4.tgz",
+      "integrity": "sha512-+PQToTb2txA0A6450/IbJHotrFVGGAKWsU22hLCvpzcT9Zj1F3NInkkDAMjZ7Na4nofNzyc82ED8MWafwhxFmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/stream-compression": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.4.tgz",
+      "integrity": "sha512-gr6Y2N7XTW1ceh8yycFE/h7u4hLHWwmyvFwtjfb0U1FWIRerpXzyVwy9Fzlw3D8vgAsMpeM4OZdZ2MWyC8kN1g==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/node-polyfills": "3.1.4",
+        "@php-wasm/util": "3.1.4"
+      }
+    },
+    "node_modules/@php-wasm/universal": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.4.tgz",
+      "integrity": "sha512-9JWhjHZ3ZwnzqaR7ZuRfGdCvLjxdbg4Ok23PgVjsoMOCoFZWm6LUvR0nfZ7tRuKue8Bgwzzssx6RuwCy7Z5dIQ==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node-polyfills": "3.1.4",
+        "@php-wasm/progress": "3.1.4",
+        "@php-wasm/stream-compression": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/util": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.4.tgz",
+      "integrity": "sha512-JAJGJAU/D5N/4pAvNEUZaDBZlFVMkjUYR7MAEsm3Dtq8yqsjl4oNRI43zpvdnfzSd6FVf0jOB5AVrC3wfv83yQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/web-service-worker": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.4.tgz",
+      "integrity": "sha512-DTJVoz8x5xTPBv3xNGJSmf3tXeYet0CXK0HWX7IRS4Zor3N8kzDLn9si2K61tJ5063P0rczQ/fp/YhNAhQVkkw==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/scopes": "3.1.4"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/xdebug-bridge": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.4.tgz",
+      "integrity": "sha512-s6iZjVPUEFp/xhU+kGq2gnSMbZeS+w0TWSdikb+HjBl1Uzh+xAwTGCEey+PsvmRL7VkZ/PLWxwP9xq6GsDQ5YQ==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node": "3.1.4",
+        "@php-wasm/universal": "3.1.4",
+        "@wp-playground/common": "3.1.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.3.4",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3",
+        "xml2js": "0.6.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "xdebug-bridge": "xdebug-bridge.js"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.161",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+      "dev": true
+    },
+    "node_modules/@types/btoa-lite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+      "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+      "dev": true
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@wordpress/env": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.1.0.tgz",
+      "integrity": "sha512-fhpE6a7jmTLvaCvSqq0oSW/EH/UsgWxefZm8iV5q558jF2Ri97exmmGtoI8+wskYj8ivzIwNXPat7idBtYubtg==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/prompts": "^7.2.0",
+        "@wp-playground/cli": "^3.0.48",
+        "chalk": "^4.0.0",
+        "copy-dir": "^1.3.0",
+        "cross-spawn": "^7.0.6",
+        "docker-compose": "^0.24.3",
+        "extract-zip": "^1.6.7",
+        "got": "^11.8.5",
+        "js-yaml": "^3.13.1",
+        "ora": "^4.0.2",
+        "rimraf": "^5.0.10",
+        "simple-git": "^3.5.0",
+        "yargs": "^17.3.0"
+      },
+      "bin": {
+        "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wp-playground/blueprints": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.4.tgz",
+      "integrity": "sha512-prKI8WbKehbQX77nO1y3+XsUgV5mZeQdsndmecWVRKrZXQc3d0RkTCcckkZCYWHYhESF2L4rvzxShwRvSA6jxw==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node": "3.1.4",
+        "@php-wasm/node-polyfills": "3.1.4",
+        "@php-wasm/progress": "3.1.4",
+        "@php-wasm/scopes": "3.1.4",
+        "@php-wasm/stream-compression": "3.1.4",
+        "@php-wasm/universal": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "@php-wasm/web-service-worker": "3.1.4",
+        "@wp-playground/common": "3.1.4",
+        "@wp-playground/storage": "3.1.4",
+        "@wp-playground/wordpress": "3.1.4",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.3.4",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ignore": "5.3.2",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/cli": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.4.tgz",
+      "integrity": "sha512-vbJZG32xhtAvNHGrhHCGMiu30wrV7nPYHFmRP0MKNclhrqPtKCUdtDSXBpoyO0aTDs92N4E/JheXJ1qYd5AJVw==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/cli-util": "3.1.4",
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node": "3.1.4",
+        "@php-wasm/progress": "3.1.4",
+        "@php-wasm/universal": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "@php-wasm/xdebug-bridge": "3.1.4",
+        "@wp-playground/blueprints": "3.1.4",
+        "@wp-playground/common": "3.1.4",
+        "@wp-playground/storage": "3.1.4",
+        "@wp-playground/tools": "3.1.4",
+        "@wp-playground/wordpress": "3.1.4",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.3.4",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "fs-extra": "11.1.1",
+        "ignore": "5.3.2",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "ps-man": "1.1.8",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
+        "tmp-promise": "3.0.3",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3",
+        "xml2js": "0.6.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "wp-playground-cli": "wp-playground.js"
+      }
+    },
+    "node_modules/@wp-playground/common": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.4.tgz",
+      "integrity": "sha512-N7R4ZQeGfecAYG/gRSWlcHVdZLGygBN6QAXpemy+xUcks/qPoO1w0VVTJp1uoVJ77b7S0cKZsMcRgh0bYZ7hIQ==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/universal": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/storage": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.4.tgz",
+      "integrity": "sha512-mstkIeE0Fw+tGw49+n7zoWr4AI3Qe/X3260yJWOvux+Fox+fXwVT1HzUV1z/jayDPnMMEVLaYeHGiUh9ZJiX0w==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/stream-compression": "3.1.4",
+        "@php-wasm/universal": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "@zip.js/zip.js": "2.7.57",
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "ini": "4.1.2",
+        "minimisted": "^2.0.0",
+        "octokit": "3.1.2",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      }
+    },
+    "node_modules/@wp-playground/storage/node_modules/diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "dev": true
+    },
+    "node_modules/@wp-playground/storage/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@wp-playground/tools": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.4.tgz",
+      "integrity": "sha512-fF6NzZbYdVMlDAJAPQJ910SagRQP4FtGkknvl3Wo/ACcTxFUhxP/zD0wbnp+74EQtvxT6KnqDmYXDtOpHT1Waw==",
+      "dev": true,
+      "dependencies": {
+        "@wp-playground/blueprints": "3.1.4",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.3.4",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ignore": "5.3.2",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/wordpress": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.4.tgz",
+      "integrity": "sha512-9xQVLBhE1etvpgxpnj8VISCgplJKkN57RSrRKalNWvfqN7D7mmJE3ZK8m0UTVLfd++tXWOAyIfOjuvjUjzXkNQ==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/logger": "3.1.4",
+        "@php-wasm/node": "3.1.4",
+        "@php-wasm/universal": "3.1.4",
+        "@php-wasm/util": "3.1.4",
+        "@wp-playground/common": "3.1.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.3.4",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.3",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.57",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+      "dev": true,
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+      "dev": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true
+    },
+    "node_modules/clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "dev": true
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true
+    },
+    "node_modules/copy-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+      "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff3": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+      "integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+      "dev": true
+    },
+    "node_modules/docker-compose": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+      "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "dev": true,
+      "dependencies": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
+      "integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-ext-extra-prebuilt": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+      "integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.24.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "name": "@wolfy1339/lru-cache",
+      "version": "11.0.2-patch.1",
+      "resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+      "integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+      "dev": true,
+      "engines": {
+        "node": "18 >=18.20 || 20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/octokit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+      "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/app": "^14.0.2",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-graphql": "^4.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/plugin-retry": "^6.0.0",
+        "@octokit/plugin-throttling": "^8.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.2.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^3.0.0",
+        "mute-stream": "0.0.8",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/pako": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "dev": true
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ps-man": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
+      "integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.32.3",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.3.tgz",
+      "integrity": "sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==",
+      "dev": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/simple-git/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+      "integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.0",
+        "jsonwebtoken": "^9.0.2"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "dev": true
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "wp-webhook-framework",
+  "private": true,
+  "description": "wp-env application test tooling for WP Webhook Framework",
+  "scripts": {
+    "wp-env:start": "wp-env start --update",
+    "wp-env:stop": "wp-env stop",
+    "wp-env:destroy": "wp-env destroy --force",
+    "composer:install": "wp-env run cli --env-cwd=wp-content/wpwf-framework composer install --prefer-dist --no-progress",
+    "test:phpunit": "wp-env run cli --env-cwd=wp-content/wpwf-framework vendor/bin/phpunit -c phpunit.xml.dist",
+    "test:integration": "npm run wp-env:start && npm run composer:install && npm run test:phpunit"
+  },
+  "devDependencies": {
+    "@wordpress/env": "11.1.0"
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/phpunit/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="Application Tests">
+      <directory suffix="Test.php">tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Delivery_Mode.php
+++ b/src/Delivery_Mode.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Delivery mode enum for webhook emissions.
+ *
+ * @package juvo\WP_Webhook_Framework
+ */
+
+declare(strict_types=1);
+
+namespace juvo\WP_Webhook_Framework;
+
+/**
+ * Controls whether webhook emissions are queued or delivered immediately.
+ *
+ * - SCHEDULED queues the webhook in Action Scheduler.
+ * - IMMEDIATE sends the first attempt in the current request.
+ */
+enum Delivery_Mode: string {
+
+	/**
+	 * Queue delivery through Action Scheduler.
+	 */
+	case SCHEDULED = 'scheduled';
+
+	/**
+	 * Send delivery immediately in the current request.
+	 */
+	case IMMEDIATE = 'immediate';
+
+	/**
+	 * Check if this mode queues delivery.
+	 *
+	 * @return bool
+	 */
+	public function is_scheduled(): bool {
+		return self::SCHEDULED === $this;
+	}
+}

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -5,6 +5,8 @@
  * @package juvo\WP_Webhook_Framework
  */
 
+declare(strict_types=1);
+
 namespace juvo\WP_Webhook_Framework;
 
 use ActionScheduler_Store;
@@ -16,16 +18,14 @@ use juvo\WP_Webhook_Framework\Entities\User;
 use WP_Exception;
 
 /**
- * Queues and sends webhooks. AS-only. Dedupe on action+entity+id.
+ * Queues and sends webhooks with scheduled and immediate modes.
+ *
+ * Scheduled mode deduplicates by action+entity+id while pending.
  */
 class Dispatcher {
 
-
 	/**
 	 * Schedule a webhook if not already pending with same (action, entity, id).
-	 *
-	 * Accepts a Webhook instance for strongly-typed configuration access during scheduling.
-	 * Only the webhook name is persisted to Action Scheduler for later lookup.
 	 *
 	 * @param string              $action        The action type.
 	 * @param string              $entity        The entity type.
@@ -37,36 +37,15 @@ class Dispatcher {
 	 * @throws WP_Exception If Action Scheduler is not active or URL/payload issues.
 	 */
 	public function schedule( string $action, string $entity, int|string $id, string $url = '', array $payload = array(), array $headers = array() ): void {
+		$this->ensure_action_scheduler_available();
 
-		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_get_scheduled_actions' ) ) {
-			throw new WP_Exception( 'action_scheduler_not_active' );
-		}
-
-		// Allow filters to modify or set the URL at dispatch time
-		$url = apply_filters( 'wpwf_url', $url, $entity, $id );
-
-		if ( empty( $url ) ) {
-			throw new WP_Exception( 'webhook_url_not_set' );
-		}
-
-		// Check if this URL is blocked due to too many failures
-		if ( $this->is_url_blocked( $url ) ) {
-			throw new WP_Exception( 'webhook_url_blocked' );
-		}
-
-		$original_payload = $payload;
-		$payload          = apply_filters( 'wpwf_payload', $payload, $entity, $id );
-		if ( false === $payload || null === $payload ) {
+		$dispatch_data = $this->resolve_dispatch_data( $entity, $id, $url, $payload );
+		if ( null === $dispatch_data ) {
 			return;
 		}
 
-		if ( ! is_array( $payload ) ) {
-			throw new WP_Exception( 'webhook_payload_invalid' );
-		}
-
-		if ( empty( $payload ) && ! empty( $original_payload ) ) {
-			throw new WP_Exception( 'webhook_payload_empty' );
-		}
+		$url     = $dispatch_data['url'];
+		$payload = $dispatch_data['payload'];
 
 		$group = sanitize_title( 'wpwf-' . $entity );
 
@@ -106,7 +85,94 @@ class Dispatcher {
 	}
 
 	/**
-	 * Action Scheduler callback. Sends the POST request non-blocking.
+	 * Deliver a webhook immediately in the current request.
+	 *
+	 * Uses the same URL and payload filters as scheduled dispatch.
+	 * Failures can still schedule asynchronous retries.
+	 *
+	 * @param string              $action        The action type.
+	 * @param string              $entity        The entity type.
+	 * @param int|string          $id            The entity ID.
+	 * @param string              $url           The webhook URL.
+	 * @param array<string,mixed> $payload       The request payload data.
+	 * @param array<string,mixed> $headers       The request headers.
+	 *
+	 * @throws WP_Exception If URL/payload/webhook configuration is invalid.
+	 */
+	public function dispatch_immediately( string $action, string $entity, int|string $id, string $url = '', array $payload = array(), array $headers = array() ): void {
+		$dispatch_data = $this->resolve_dispatch_data( $entity, $id, $url, $payload );
+		if ( null === $dispatch_data ) {
+			return;
+		}
+
+		$webhook = $this->get_webhook_from_headers( $headers );
+
+		$this->send_webhook_request(
+			$dispatch_data['url'],
+			$action,
+			$entity,
+			$id,
+			$dispatch_data['payload'],
+			$headers,
+			$webhook
+		);
+	}
+
+	/**
+	 * Ensure Action Scheduler APIs required for queued actions are available.
+	 *
+	 * @throws WP_Exception If Action Scheduler functions are not loaded.
+	 */
+	private function ensure_action_scheduler_available(): void {
+		if ( ! function_exists( 'as_schedule_single_action' ) || ! function_exists( 'as_get_scheduled_actions' ) ) {
+			throw new WP_Exception( 'action_scheduler_not_active' );
+		}
+	}
+
+	/**
+	 * Resolve URL and payload through shared dispatch validation.
+	 *
+	 * @param string              $entity  The entity type.
+	 * @param int|string          $id      The entity ID.
+	 * @param string              $url     The webhook URL.
+	 * @param array<string,mixed> $payload The payload data.
+	 * @return array{url: string, payload: array<string,mixed>}|null
+	 *
+	 * @throws WP_Exception If URL or payload validation fails.
+	 */
+	private function resolve_dispatch_data( string $entity, int|string $id, string $url, array $payload ): ?array {
+		$url = apply_filters( 'wpwf_url', $url, $entity, $id );
+
+		if ( empty( $url ) ) {
+			throw new WP_Exception( 'webhook_url_not_set' );
+		}
+
+		if ( $this->is_url_blocked( $url ) ) {
+			throw new WP_Exception( 'webhook_url_blocked' );
+		}
+
+		$original_payload = $payload;
+		$payload          = apply_filters( 'wpwf_payload', $payload, $entity, $id );
+		if ( false === $payload || null === $payload ) {
+			return null;
+		}
+
+		if ( ! is_array( $payload ) ) {
+			throw new WP_Exception( 'webhook_payload_invalid' );
+		}
+
+		if ( empty( $payload ) && ! empty( $original_payload ) ) {
+			throw new WP_Exception( 'webhook_payload_empty' );
+		}
+
+		return array(
+			'url'     => $url,
+			'payload' => $payload,
+		);
+	}
+
+	/**
+	 * Action Scheduler callback for queued webhook deliveries.
 	 *
 	 * Reconstructs the webhook instance from the registry using the persisted webhook name.
 	 *
@@ -117,20 +183,50 @@ class Dispatcher {
 	 * @param array<string,mixed> $payload      The payload data.
 	 * @param array<string,mixed> $headers      The HTTP headers.
 	 *
-	 * @throws WP_Exception If Action Scheduler is not active or URL is blocked.
+	 * @throws WP_Exception If URL is blocked or webhook is not found.
 	 */
-	public function process_scheduled_webhook( string $url, string $action, string $entity, $id, array $payload, array $headers ): void {
+	public function process_scheduled_webhook( string $url, string $action, string $entity, int|string $id, array $payload, array $headers ): void {
+		$webhook = $this->get_webhook_from_headers( $headers );
 
-		// Check if this URL is blocked due to too many failures
-		if ( $this->is_url_blocked( $url ) ) {
-			throw new WP_Exception( 'webhook_url_blocked' );
+		$this->send_webhook_request( $url, $action, $entity, $id, $payload, $headers, $webhook );
+	}
+
+	/**
+	 * Resolve the webhook instance from scheduled headers.
+	 *
+	 * @param array<string,mixed> $headers The webhook headers.
+	 * @return Webhook
+	 *
+	 * @throws WP_Exception If the webhook cannot be resolved from the registry.
+	 */
+	private function get_webhook_from_headers( array $headers ): Webhook {
+		$registry = Webhook_Registry::instance();
+		$name     = isset( $headers['wpwf-webhook-name'] ) ? (string) $headers['wpwf-webhook-name'] : '';
+		$webhook  = $registry->get( $name );
+
+		if ( null === $webhook ) {
+			throw new WP_Exception( 'Webhook not found in registry.' );
 		}
 
-		// Reconstruct webhook instance from registry
-		$registry = Webhook_Registry::instance();
-		$webhook  = $registry->get( $headers['wpwf-webhook-name'] ?? '' );
-		if ( empty( $webhook ) ) {
-			throw new WP_Exception( 'Webhook not found in registry.' );
+		return $webhook;
+	}
+
+	/**
+	 * Send a webhook request and handle retries and failure tracking.
+	 *
+	 * @param string              $url     The webhook URL.
+	 * @param string              $action  The action type.
+	 * @param string              $entity  The entity type.
+	 * @param int|string          $id      The entity ID.
+	 * @param array<string,mixed> $payload The payload data.
+	 * @param array<string,mixed> $headers The HTTP headers.
+	 * @param Webhook             $webhook The webhook configuration instance.
+	 *
+	 * @throws WP_Exception If delivery fails.
+	 */
+	private function send_webhook_request( string $url, string $action, string $entity, int|string $id, array $payload, array $headers, Webhook $webhook ): void {
+		if ( $this->is_url_blocked( $url ) ) {
+			throw new WP_Exception( 'webhook_url_blocked' );
 		}
 
 		$payload = $this->prepare_delivery_payload( $entity, $id, $payload );
@@ -170,18 +266,16 @@ class Dispatcher {
 
 		$response = wp_remote_post( $url, $args );
 
-		// Check if the request was successful
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			$this->schedule_retry_if_applicable( $url, $action, $entity, $id, $payload, $headers, $webhook );
 			$this->trigger_webhook_failure( $url, $response, $webhook );
-		} else {
-
-			// Reset failure count and unblock on success
-			$failure_dto = Failure::create_fresh();
-			$failure_dto->save( $url );
-
-			do_action( 'wpwf_webhook_success', $url, $body, $response, $webhook );
+			return;
 		}
+
+		$failure_dto = Failure::create_fresh();
+		$failure_dto->save( $url );
+
+		do_action( 'wpwf_webhook_success', $url, $body, $response, $webhook );
 	}
 
 	/**
@@ -304,8 +398,8 @@ class Dispatcher {
 
 		// Check if block has expired (more than 1 hour ago)
 		if ( $failure_dto->is_block_expired() ) {
-			// Unblock automatically
-			$failure_dto->set_blocked( false );
+			// Expired blocks start a fresh failure window.
+			$failure_dto->reset();
 			$failure_dto->save( $url );
 			return false;
 		}
@@ -324,7 +418,7 @@ class Dispatcher {
 	 * @param array<string,mixed> $headers      The headers.
 	 * @param Webhook|null        $webhook      Webhook instance for configuration.
 	 */
-	private function schedule_retry_if_applicable( string $url, string $action, string $entity, $id, array $payload, array $headers, ?Webhook $webhook ): void {
+	private function schedule_retry_if_applicable( string $url, string $action, string $entity, int|string $id, array $payload, array $headers, ?Webhook $webhook ): void {
 		if ( ! $webhook ) {
 			return;
 		}
@@ -343,6 +437,8 @@ class Dispatcher {
 
 		// Update headers with new retry count
 		$headers['wpwf-retry-count'] = $next_retry;
+
+		$this->ensure_action_scheduler_available();
 
 		// Schedule the retry
 		as_schedule_single_action(

--- a/src/Notifications/Notification_Registry.php
+++ b/src/Notifications/Notification_Registry.php
@@ -32,6 +32,16 @@ class Notification_Registry {
 	private array $notifications = array();
 
 	/**
+	 * Initialized notification identifiers.
+	 *
+	 * Guards against duplicate hook registration when multiple webhooks enable
+	 * the same notification handler.
+	 *
+	 * @var array<string,true>
+	 */
+	private array $initialized_notifications = array();
+
+	/**
 	 * Private constructor to enforce singleton pattern.
 	 */
 	private function __construct() {
@@ -83,7 +93,7 @@ class Notification_Registry {
 	 */
 	public function init_all(): void {
 		foreach ( $this->notifications as $notification ) {
-			$notification->init();
+			$this->init_notification( $notification );
 		}
 	}
 
@@ -117,8 +127,24 @@ class Notification_Registry {
 	public function init_selected( array $identifiers ): void {
 		foreach ( $identifiers as $identifier ) {
 			if ( isset( $this->notifications[ $identifier ] ) ) {
-				$this->notifications[ $identifier ]->init();
+				$this->init_notification( $this->notifications[ $identifier ] );
 			}
 		}
+	}
+
+	/**
+	 * Initialize a notification handler only once.
+	 *
+	 * @param Notification $notification The notification handler.
+	 */
+	private function init_notification( Notification $notification ): void {
+		$identifier = $notification->get_identifier();
+
+		if ( isset( $this->initialized_notifications[ $identifier ] ) ) {
+			return;
+		}
+
+		$notification->init();
+		$this->initialized_notifications[ $identifier ] = true;
 	}
 }

--- a/src/Service_Provider.php
+++ b/src/Service_Provider.php
@@ -128,8 +128,8 @@ class Service_Provider {
 	 * Registers webhooks and notification handlers during WordPress initialization.
 	 */
 	public function on_init(): void {
-		$this->register_webhooks();
 		$this->register_available_notifications();
+		$this->register_webhooks();
 	}
 
 	/**

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -70,6 +70,13 @@ abstract class Webhook {
 	protected string $webhook_url = '';
 
 	/**
+	 * Delivery mode for webhook emissions.
+	 *
+	 * @var Delivery_Mode
+	 */
+	protected Delivery_Mode $delivery_mode;
+
+	/**
 	 * Additional HTTP headers for webhook requests.
 	 *
 	 * Stateless configuration set during init(), not per-emission data.
@@ -94,6 +101,7 @@ abstract class Webhook {
 	public function __construct( string $name ) {
 		$this->name                         = $name;
 		$this->headers['wpwf-webhook-name'] = $name;
+		$this->delivery_mode                = Delivery_Mode::SCHEDULED;
 	}
 
 	/**
@@ -143,6 +151,17 @@ abstract class Webhook {
 	 */
 	public function webhook_url( string $url ): static {
 		$this->webhook_url = $url;
+		return $this;
+	}
+
+	/**
+	 * Set delivery mode for webhook emissions.
+	 *
+	 * @param Delivery_Mode $mode The delivery mode.
+	 * @return static
+	 */
+	public function delivery_mode( Delivery_Mode $mode ): static {
+		$this->delivery_mode = $mode;
 		return $this;
 	}
 
@@ -281,6 +300,24 @@ abstract class Webhook {
 	}
 
 	/**
+	 * Get the configured delivery mode.
+	 *
+	 * @return Delivery_Mode
+	 */
+	public function get_delivery_mode(): Delivery_Mode {
+		/**
+		 * Filter the webhook delivery mode.
+		 *
+		 * @param string $delivery_mode The delivery mode value (`scheduled` or `immediate`).
+		 * @param string $webhook_name  The webhook name/identifier.
+		 */
+		$delivery_mode = apply_filters( 'wpwf_delivery_mode', $this->delivery_mode->value, $this->name );
+
+		$resolved_mode = Delivery_Mode::tryFrom( $delivery_mode );
+		return $resolved_mode ?? $this->delivery_mode;
+	}
+
+	/**
 	 * Get additional HTTP headers.
 	 *
 	 * Returns stateless configuration headers set during init().
@@ -301,27 +338,35 @@ abstract class Webhook {
 	/**
 	 * Emit a webhook with the given parameters.
 	 *
-	 * Schedules a webhook delivery via the Dispatcher using this webhook's configuration.
+	 * Dispatches a webhook via the Dispatcher using this webhook's configuration.
 	 * Payload and headers passed as parameters are merged with configured headers.
 	 *
 	 * @param string              $action      The action type (create, update, delete).
 	 * @param string              $entity_type The entity type (post, term, user, meta).
 	 * @param int|string          $entity_id   The entity ID.
 	 * @param array<string,mixed> $payload     Dynamic payload data for this emission.
-	 * @param array<string,mixed> $headers     Optional dynamic headers (merged with get_headers()).
+	 * @param array<string,mixed> $headers       Optional dynamic headers (merged with get_headers()).
+	 * @param Delivery_Mode|null  $delivery_mode Optional per-emission mode override.
 	 */
-	protected function emit( string $action, string $entity_type, int|string $entity_id, array $payload = array(), array $headers = array() ): void {
+	protected function emit( string $action, string $entity_type, int|string $entity_id, array $payload = array(), array $headers = array(), ?Delivery_Mode $delivery_mode = null ): void {
 		$registry   = Webhook_Registry::instance();
 		$dispatcher = $registry->get_dispatcher();
 
 		// Merge passed headers with configured headers (passed headers take precedence)
 		$final_headers = array_merge( $this->get_headers(), $headers );
 
+		$resolved_delivery_mode = $delivery_mode ?? $this->get_delivery_mode();
+
 		try {
+			if ( Delivery_Mode::IMMEDIATE === $resolved_delivery_mode ) {
+				$dispatcher->dispatch_immediately( $action, $entity_type, $entity_id, $this->get_webhook_url(), $payload, $final_headers );
+				return;
+			}
+
 			$dispatcher->schedule( $action, $entity_type, $entity_id, $this->get_webhook_url(), $payload, $final_headers );
 		} catch ( \WP_Exception $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped -- Error handling context, no escaping needed.
-			trigger_error( sprintf( 'Failed to schedule webhook "%s": %s', $this->name, $e->getMessage() ), E_USER_WARNING );
+			trigger_error( sprintf( 'Failed to emit webhook "%s": %s', $this->name, $e->getMessage() ), E_USER_WARNING );
 		}
 	}
 }

--- a/src/Webhooks/Meta_Webhook.php
+++ b/src/Webhooks/Meta_Webhook.php
@@ -231,7 +231,7 @@ class Meta_Webhook extends Webhook {
 			return;
 		}
 
-		$this->on_meta_update( 'post', $object_id, $meta_key, $meta_value );
+		$this->on_meta_delete( 'post', $object_id, $meta_key );
 	}
 
 	/**
@@ -263,7 +263,7 @@ class Meta_Webhook extends Webhook {
 	 * @param mixed  $meta_value The meta value.
 	 */
 	public function on_deleted_term_meta( $meta_ids, int $object_id, string $meta_key, $meta_value ): void {
-		$this->on_meta_update( 'term', $object_id, $meta_key, $meta_value );
+		$this->on_meta_delete( 'term', $object_id, $meta_key );
 	}
 
 	/**
@@ -295,7 +295,34 @@ class Meta_Webhook extends Webhook {
 	 * @param mixed  $meta_value The meta value.
 	 */
 	public function on_deleted_user_meta( $meta_ids, int $object_id, string $meta_key, $meta_value ): void {
-		$this->on_meta_update( 'user', $object_id, $meta_key, $meta_value );
+		$this->on_meta_delete( 'user', $object_id, $meta_key );
+	}
+
+	/**
+	 * Handle explicit metadata deletion events.
+	 *
+	 * Deletion hooks already guarantee the intended action, so this path bypasses
+	 * value-based change detection and emits a delete directly.
+	 *
+	 * @param string $meta_type The meta type (post, term, user).
+	 * @param int    $object_id The object ID.
+	 * @param string $meta_key  The meta key.
+	 */
+	private function on_meta_delete( string $meta_type, int $object_id, string $meta_key ): void {
+		if ( $this->meta_handler->is_meta_key_excluded( $meta_key, $meta_type, $object_id ) ) {
+			return;
+		}
+
+		self::unmark_as_processed( $meta_type, $object_id, $meta_key );
+
+		if ( $this->emission_mode->includes_meta() ) {
+			$payload = $this->meta_handler->prepare_payload( $meta_type, $object_id, $meta_key );
+			$this->emit( 'delete', 'meta', $object_id, $payload );
+		}
+
+		if ( $this->emission_mode->includes_entity() ) {
+			$this->trigger_entity_update( $meta_type, $object_id );
+		}
 	}
 
 	/**

--- a/src/Webhooks/Post_Webhook.php
+++ b/src/Webhooks/Post_Webhook.php
@@ -71,6 +71,10 @@ class Post_Webhook extends Webhook {
 	 * @param int $post_id The post ID.
 	 */
 	public function on_delete_post( int $post_id ): void {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
 		$payload = $this->post_handler->prepare_payload( $post_id );
 		$this->emit( 'delete', 'post', $post_id, $payload );
 	}

--- a/tests/phpunit/CustomWebhookTest.php
+++ b/tests/phpunit/CustomWebhookTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Covers custom webhook registration and delivery.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * Verifies consumer-defined webhook classes integrate through the registry.
+ */
+final class CustomWebhookTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures the fixture custom webhook can schedule and dispatch a payload.
+	 */
+	public function test_custom_webhook_trigger_dispatches_expected_payload(): void {
+		\do_action(
+			'wpwf_test_custom_event',
+			'job-123',
+			array(
+				'status' => 'queued',
+			)
+		);
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'custom_primary' );
+
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'trigger', $actions[0]['action'] );
+		$this->assertSame( 'custom', $actions[0]['entity'] );
+		$this->assertSame( 'job-123', $actions[0]['id'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'custom_primary' );
+
+		$this->assertSame( 'https://wpwf.test/primary/custom', $request['url'] );
+		$this->assertSame( 'trigger', $request['body']['action'] );
+		$this->assertSame( 'custom', $request['body']['entity'] );
+		$this->assertSame( 'job-123', $request['body']['id'] );
+		$this->assertSame( 'job-123', $request['body']['reference'] );
+		$this->assertSame( array( 'status' => 'queued' ), $request['body']['context'] );
+	}
+}

--- a/tests/phpunit/CustomWebhookTest.php
+++ b/tests/phpunit/CustomWebhookTest.php
@@ -35,7 +35,7 @@ final class CustomWebhookTest extends WPWF_Webhook_Test_Case {
 
 		$request = $this->get_captured_request_by_webhook_name( 'custom_primary' );
 
-		$this->assertSame( 'https://wpwf.test/primary/custom', $request['url'] );
+		$this->assertSame( $this->get_receiver_webhook_url( 'primary-custom' ), $request['url'] );
 		$this->assertSame( 'trigger', $request['body']['action'] );
 		$this->assertSame( 'custom', $request['body']['entity'] );
 		$this->assertSame( 'job-123', $request['body']['id'] );

--- a/tests/phpunit/DeliveryModeTest.php
+++ b/tests/phpunit/DeliveryModeTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Covers scheduled and immediate delivery modes.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhook;
+
+/**
+ * Verifies webhook delivery mode behavior across scheduling and immediate sends.
+ */
+final class DeliveryModeTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures scheduled mode queues work and delivers only after action execution.
+	 */
+	public function test_scheduled_mode_queues_and_delivers_via_action_scheduler(): void {
+		$webhook = $this->register_test_webhook(
+			'scheduled',
+			$this->get_receiver_webhook_url( 'delivery-mode-scheduled' ),
+			Delivery_Mode::SCHEDULED
+		);
+
+		$webhook->trigger_event( 'job-scheduled', array( 'scope' => 'scheduled' ) );
+
+		$this->assertCount( 0, $this->get_captured_requests() );
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() );
+		$this->assertCount( 1, $actions );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( $webhook->get_name() );
+		$this->assertSame( 'trigger', $request['body']['action'] );
+		$this->assertSame( 'delivery_mode', $request['body']['entity'] );
+		$this->assertSame( 'job-scheduled', $request['body']['id'] );
+		$this->assertSame( array( 'scope' => 'scheduled' ), $request['body']['context'] );
+	}
+
+	/**
+	 * Ensures immediate mode sends the first attempt without queuing.
+	 */
+	public function test_immediate_mode_sends_without_queueing(): void {
+		$webhook = $this->register_test_webhook(
+			'immediate',
+			$this->get_receiver_webhook_url( 'delivery-mode-immediate' ),
+			Delivery_Mode::IMMEDIATE
+		);
+
+		$webhook->trigger_event( 'job-immediate', array( 'scope' => 'immediate' ) );
+
+		$requests = $this->get_captured_requests();
+		$this->assertCount( 1, $requests );
+		$this->assertSame( $webhook->get_name(), $requests[0]['webhook_name'] );
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() );
+		$this->assertCount( 0, $actions );
+	}
+
+	/**
+	 * Register a dedicated test webhook with an isolated unique name.
+	 *
+	 * @param string        $suffix        Name suffix for readability.
+	 * @param string        $url           Delivery URL.
+	 * @param Delivery_Mode $delivery_mode Delivery mode under test.
+	 * @return Delivery_Mode_Test_Webhook
+	 */
+	private function register_test_webhook( string $suffix, string $url, Delivery_Mode $delivery_mode ): Delivery_Mode_Test_Webhook {
+		$name    = 'delivery_mode_' . $suffix . '_' . str_replace( '.', '', uniqid( '', true ) );
+		$webhook = new Delivery_Mode_Test_Webhook( $name, $url, $delivery_mode );
+
+		Service_Provider::get_registry()->register( $webhook );
+
+		return $webhook;
+	}
+}
+
+/**
+ * Emits fixture payloads for delivery mode tests.
+ */
+final class Delivery_Mode_Test_Webhook extends Webhook {
+
+	/**
+	 * Configure URL and delivery mode for this fixture webhook.
+	 *
+	 * @param string        $name          Unique webhook name.
+	 * @param string        $url           Delivery URL.
+	 * @param Delivery_Mode $delivery_mode Delivery mode under test.
+	 */
+	public function __construct( string $name, string $url, Delivery_Mode $delivery_mode ) {
+		parent::__construct( $name );
+
+		$this->webhook_url( $url );
+		$this->delivery_mode( $delivery_mode );
+	}
+
+	/**
+	 * No WordPress hooks are needed for this fixture webhook.
+	 */
+	public function init(): void {
+	}
+
+	/**
+	 * Emit a deterministic payload for assertions.
+	 *
+	 * @param string              $reference Stable ID used by assertions.
+	 * @param array<string,mixed> $context   Additional context.
+	 */
+	public function trigger_event( string $reference, array $context = array() ): void {
+		$this->emit(
+			'trigger',
+			'delivery_mode',
+			$reference,
+			array(
+				'reference' => $reference,
+				'context'   => $context,
+			)
+		);
+	}
+}

--- a/tests/phpunit/MetaWebhookTest.php
+++ b/tests/phpunit/MetaWebhookTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Covers application-level meta webhook behavior.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Emission_Mode;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Webhook;
+
+/**
+ * Verifies meta webhook emission modes and delivery payloads.
+ */
+final class MetaWebhookTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures the default BOTH mode emits meta and parent post updates.
+	 */
+	public function test_post_meta_both_mode_dispatches_meta_and_parent_update(): void {
+		$meta_webhook = $this->get_meta_webhook();
+		$meta_webhook->emission_mode( Meta_Emission_Mode::BOTH );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Meta post',
+			)
+		);
+
+		add_post_meta( $post_id, 'favorite_color', 'red', true );
+		$this->clear_scheduled_webhooks();
+		$this->reset_captured_requests();
+
+		update_post_meta( $post_id, 'favorite_color', 'blue' );
+
+		$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'meta' ) );
+		$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'post' ) );
+
+		$this->run_scheduled_webhooks();
+
+		$meta_request = $this->get_captured_request_by_webhook_name( 'meta' );
+		$post_request = $this->get_captured_request_by_webhook_name( 'post' );
+
+		$this->assertSame( 'update', $meta_request['body']['action'] );
+		$this->assertSame( 'meta', $meta_request['body']['entity'] );
+		$this->assertSame( 'post', $meta_request['body']['meta_type'] );
+		$this->assertSame( 'favorite_color', $meta_request['body']['meta_key'] );
+		$this->assertSame( 'post', $meta_request['body']['post_type'] );
+		$this->assertStringContainsString( '/wp/v2/posts/' . $post_id, $meta_request['body']['rest_url'] );
+
+		$this->assertSame( 'update', $post_request['body']['action'] );
+		$this->assertSame( 'post', $post_request['body']['entity'] );
+		$this->assertSame( $post_id, $post_request['body']['id'] );
+	}
+
+	/**
+	 * Ensures ENTITY mode only emits the parent entity update.
+	 */
+	public function test_post_meta_entity_mode_only_dispatches_parent_update(): void {
+		$meta_webhook = $this->get_meta_webhook();
+		$meta_webhook->emission_mode( Meta_Emission_Mode::ENTITY );
+
+		try {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_title' => 'Entity mode post',
+				)
+			);
+
+			add_post_meta( $post_id, 'entity_only_key', 'before', true );
+			$this->clear_scheduled_webhooks();
+			$this->reset_captured_requests();
+
+			update_post_meta( $post_id, 'entity_only_key', 'after' );
+
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'meta' ) );
+			$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'post' ) );
+
+			$this->run_scheduled_webhooks();
+
+			$requests = $this->get_captured_requests();
+			$this->assertCount( 1, $requests );
+			$this->assertSame( 'post', $requests[0]['webhook_name'] );
+			$this->assertSame( 'update', $requests[0]['body']['action'] );
+		} finally {
+			$meta_webhook->emission_mode( Meta_Emission_Mode::BOTH );
+		}
+	}
+
+	/**
+	 * Ensures META mode emits only the meta webhook for term changes.
+	 */
+	public function test_term_meta_meta_mode_only_dispatches_meta_webhook(): void {
+		$meta_webhook = $this->get_meta_webhook();
+		$meta_webhook->emission_mode( Meta_Emission_Mode::META );
+
+		try {
+			$term = wp_insert_term( 'Meta term', 'category' );
+			$this->assertIsArray( $term );
+			$term_id = (int) $term['term_id'];
+
+			add_term_meta( $term_id, 'term_color', 'green', true );
+			$this->clear_scheduled_webhooks();
+			$this->reset_captured_requests();
+
+			update_term_meta( $term_id, 'term_color', 'yellow' );
+
+			$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'meta' ) );
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'term' ) );
+
+			$this->run_scheduled_webhooks();
+
+			$request = $this->get_captured_request_by_webhook_name( 'meta' );
+			$this->assertSame( 'update', $request['body']['action'] );
+			$this->assertSame( 'term', $request['body']['meta_type'] );
+			$this->assertSame( 'term_color', $request['body']['meta_key'] );
+			$this->assertSame( 'category', $request['body']['taxonomy'] );
+			$this->assertStringContainsString( '/wp/v2/categories/' . $term_id, $request['body']['rest_url'] );
+		} finally {
+			$meta_webhook->emission_mode( Meta_Emission_Mode::BOTH );
+		}
+	}
+
+	/**
+	 * Ensures user meta deletion emits the expected delete payloads.
+	 */
+	public function test_user_meta_delete_dispatches_meta_delete_and_parent_update(): void {
+		$meta_webhook = $this->get_meta_webhook();
+		$meta_webhook->emission_mode( Meta_Emission_Mode::BOTH );
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		add_user_meta( $user_id, 'profile_badge', 'gold', true );
+		$this->clear_scheduled_webhooks();
+		$this->reset_captured_requests();
+
+		delete_user_meta( $user_id, 'profile_badge' );
+
+		$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'meta' ) );
+		$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'user' ) );
+
+		$this->run_scheduled_webhooks();
+
+		$meta_request = $this->get_captured_request_by_webhook_name( 'meta' );
+		$user_request = $this->get_captured_request_by_webhook_name( 'user' );
+
+		$this->assertSame( 'delete', $meta_request['body']['action'] );
+		$this->assertSame( 'user', $meta_request['body']['meta_type'] );
+		$this->assertSame( 'profile_badge', $meta_request['body']['meta_key'] );
+		$this->assertSame( array( 'editor' ), $meta_request['body']['roles'] );
+		$this->assertStringContainsString( '/wp/v2/users/' . $user_id, $meta_request['body']['rest_url'] );
+
+		$this->assertSame( 'update', $user_request['body']['action'] );
+		$this->assertSame( 'user', $user_request['body']['entity'] );
+		$this->assertSame( $user_id, $user_request['body']['id'] );
+	}
+
+	/**
+	 * Returns the shared fixture meta webhook.
+	 *
+	 * @return Meta_Webhook
+	 */
+	private function get_meta_webhook(): Meta_Webhook {
+		$webhook = Service_Provider::get_registry()->get( 'meta' );
+
+		$this->assertInstanceOf( Meta_Webhook::class, $webhook );
+
+		return $webhook;
+	}
+}

--- a/tests/phpunit/MultiPluginWebhookTest.php
+++ b/tests/phpunit/MultiPluginWebhookTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Covers multiple plugins consuming the framework at once.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Service_Provider;
+
+/**
+ * Verifies separate plugins can share the framework without registry conflicts.
+ */
+final class MultiPluginWebhookTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures both fixture plugins stay active and dispatch their own webhook copies.
+	 */
+	public function test_two_plugins_can_use_the_library_without_errors(): void {
+		$registry = Service_Provider::get_registry();
+
+		$this->assertTrue( $registry->has( 'post' ) );
+		$this->assertTrue( $registry->has( 'post_secondary' ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Shared event',
+			)
+		);
+
+		$post_actions = $this->get_scheduled_webhook_actions();
+
+		$this->assertCount( 2, $post_actions );
+		$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'post' ) );
+		$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'post_secondary' ) );
+
+		$this->run_scheduled_webhooks();
+
+		$requests       = $this->get_captured_requests();
+		$webhook_names  = array_column( $requests, 'webhook_name' );
+		sort( $webhook_names );
+
+		$this->assertSame( array( 'post', 'post_secondary' ), $webhook_names );
+		$this->assertSame( $post_id, $this->get_captured_request_by_webhook_name( 'post' )['body']['id'] );
+		$this->assertSame( $post_id, $this->get_captured_request_by_webhook_name( 'post_secondary' )['body']['id'] );
+	}
+}

--- a/tests/phpunit/NotificationAndFailureStateTest.php
+++ b/tests/phpunit/NotificationAndFailureStateTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Covers blocked notifications and failure window resets.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Failure;
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhook;
+
+/**
+ * Verifies blocked notifications and expired-block recovery behavior.
+ */
+final class NotificationAndFailureStateTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures blocked notifications send exactly one email for enabled webhooks.
+	 */
+	public function test_blocked_notification_sends_email_for_enabled_webhook(): void {
+		$webhook  = $this->get_notification_webhook();
+		$url      = $this->get_receiver_webhook_url( 'notification-email', 'fail' );
+		$mail_log = array();
+
+		$webhook->webhook_url( $url );
+		$webhook->max_retries( 0 );
+
+		update_option( 'admin_email', 'alerts@example.com' );
+
+		$mail_filter = static function ( $return, array $atts ) use ( &$mail_log ) {
+			$mail_log[] = $atts;
+			return true;
+		};
+
+		add_filter( 'pre_wp_mail', $mail_filter, 10, 2 );
+
+		try {
+			do_action( 'wpwf_test_notification_event', 'job-notification-email' );
+			$this->run_scheduled_webhooks( true );
+
+			$this->assertCount( 1, $this->get_captured_requests() );
+			$this->assertCount( 1, $mail_log );
+			$this->assertSame( 'alerts@example.com', $mail_log[0]['to'] );
+			$this->assertStringContainsString( 'Webhook URL Blocked', $mail_log[0]['subject'] );
+			$this->assertStringContainsString( 'custom_blocked_notification', $mail_log[0]['message'] );
+			$this->assertStringContainsString( $url, $mail_log[0]['message'] );
+		} finally {
+			remove_filter( 'pre_wp_mail', $mail_filter, 10 );
+			$webhook->webhook_url( $this->get_receiver_webhook_url( 'primary-notification' ) );
+		}
+	}
+
+	/**
+	 * Ensures expired blocks start a fresh failure window before the next attempt.
+	 */
+	public function test_expired_block_resets_failure_window_before_next_failure(): void {
+		$webhook = $this->get_notification_webhook();
+		$url     = $this->get_receiver_webhook_url( 'notification-expired', 'fail' );
+
+		$webhook->webhook_url( $url );
+		$webhook->max_retries( 0 );
+		$webhook->max_consecutive_failures( 2 );
+
+		$swallow_mail = static function () {
+			return true;
+		};
+
+		add_filter( 'pre_wp_mail', $swallow_mail, 10, 2 );
+
+		try {
+			do_action( 'wpwf_test_notification_event', 'job-expired-block-1' );
+			$this->run_scheduled_webhooks( true );
+
+			do_action( 'wpwf_test_notification_event', 'job-expired-block-2' );
+			$this->run_scheduled_webhooks( true );
+
+			$blocked_state = Failure::from_transient( $url );
+			$this->assertSame( 2, $blocked_state->get_count() );
+			$this->assertTrue( $blocked_state->is_blocked() );
+
+			$blocked_state->set_blocked_time( time() - HOUR_IN_SECONDS - 5 );
+			$blocked_state->save( $url );
+
+			$this->reset_captured_requests();
+
+			do_action( 'wpwf_test_notification_event', 'job-expired-block-3' );
+			$this->run_scheduled_webhooks( true );
+
+			$this->assertCount( 1, $this->get_captured_requests() );
+
+			$reset_state = Failure::from_transient( $url );
+			$this->assertSame( 1, $reset_state->get_count() );
+			$this->assertFalse( $reset_state->is_blocked() );
+		} finally {
+			remove_filter( 'pre_wp_mail', $swallow_mail, 10 );
+			$webhook->webhook_url( $this->get_receiver_webhook_url( 'primary-notification' ) );
+			$webhook->max_consecutive_failures( 1 );
+		}
+	}
+
+	/**
+	 * Returns the fixture webhook that enables blocked notifications.
+	 *
+	 * @return Webhook
+	 */
+	private function get_notification_webhook(): Webhook {
+		$webhook = Service_Provider::get_registry()->get( 'custom_blocked_notification' );
+
+		$this->assertInstanceOf( Webhook::class, $webhook );
+
+		return $webhook;
+	}
+}

--- a/tests/phpunit/PostWebhookCrudTest.php
+++ b/tests/phpunit/PostWebhookCrudTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Covers post lifecycle webhook behaviour.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * Verifies post webhooks dispatch stable CRUD payloads for multiple consumers.
+ */
+final class PostWebhookCrudTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures post create, update, and delete events dispatch through both fixture consumers.
+	 */
+	public function test_post_create_update_and_delete_webhooks(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Initial title',
+				'post_type'  => 'post',
+			)
+		);
+
+		$primary_actions   = $this->get_scheduled_actions_by_webhook_name( 'post' );
+		$secondary_actions = $this->get_scheduled_actions_by_webhook_name( 'post_secondary' );
+
+		$this->assertCount( 1, $primary_actions );
+		$this->assertCount( 1, $secondary_actions );
+		$this->assertSame( 'create', $primary_actions[0]['action'] );
+		$this->assertSame( 'post', $primary_actions[0]['entity'] );
+		$this->assertSame( $post_id, $primary_actions[0]['id'] );
+
+		$this->run_scheduled_webhooks();
+
+		$primary_request   = $this->get_captured_request_by_webhook_name( 'post' );
+		$secondary_request = $this->get_captured_request_by_webhook_name( 'post_secondary' );
+
+		$this->assertSame( 'https://wpwf.test/primary/post', $primary_request['url'] );
+		$this->assertSame( 'create', $primary_request['body']['action'] );
+		$this->assertSame( 'post', $primary_request['body']['entity'] );
+		$this->assertSame( $post_id, $primary_request['body']['id'] );
+		$this->assertSame( 'post', $primary_request['body']['post_type'] );
+		$this->assertStringContainsString( '/wp/v2/posts/' . $post_id, $primary_request['body']['rest_url'] );
+
+		$this->assertSame( 'https://wpwf.test/secondary/post', $secondary_request['url'] );
+		$this->assertSame( 'create', $secondary_request['body']['action'] );
+		$this->assertSame( $post_id, $secondary_request['body']['id'] );
+
+		$this->reset_captured_requests();
+
+		\wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Updated title',
+			)
+		);
+
+		$primary_actions   = $this->get_scheduled_actions_by_webhook_name( 'post' );
+		$secondary_actions = $this->get_scheduled_actions_by_webhook_name( 'post_secondary' );
+
+		$this->assertCount( 1, $primary_actions );
+		$this->assertCount( 1, $secondary_actions );
+		$this->assertSame( 'update', $primary_actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$primary_request   = $this->get_captured_request_by_webhook_name( 'post' );
+		$secondary_request = $this->get_captured_request_by_webhook_name( 'post_secondary' );
+
+		$this->assertSame( 'update', $primary_request['body']['action'] );
+		$this->assertSame( 'post', $primary_request['body']['post_type'] );
+		$this->assertSame( 'update', $secondary_request['body']['action'] );
+
+		$this->reset_captured_requests();
+
+		\wp_delete_post( $post_id, true );
+
+		$primary_actions   = $this->get_scheduled_actions_by_webhook_name( 'post' );
+		$secondary_actions = $this->get_scheduled_actions_by_webhook_name( 'post_secondary' );
+
+		$this->assertCount( 1, $primary_actions );
+		$this->assertCount( 1, $secondary_actions );
+		$this->assertSame( 'delete', $primary_actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$primary_request   = $this->get_captured_request_by_webhook_name( 'post' );
+		$secondary_request = $this->get_captured_request_by_webhook_name( 'post_secondary' );
+
+		$this->assertSame( 'delete', $primary_request['body']['action'] );
+		$this->assertSame( 'post', $primary_request['body']['entity'] );
+		$this->assertSame( $post_id, $primary_request['body']['id'] );
+		$this->assertSame( 'delete', $secondary_request['body']['action'] );
+	}
+}

--- a/tests/phpunit/PostWebhookCrudTest.php
+++ b/tests/phpunit/PostWebhookCrudTest.php
@@ -37,14 +37,14 @@ final class PostWebhookCrudTest extends WPWF_Webhook_Test_Case {
 		$primary_request   = $this->get_captured_request_by_webhook_name( 'post' );
 		$secondary_request = $this->get_captured_request_by_webhook_name( 'post_secondary' );
 
-		$this->assertSame( 'https://wpwf.test/primary/post', $primary_request['url'] );
+		$this->assertSame( $this->get_receiver_webhook_url( 'primary-post' ), $primary_request['url'] );
 		$this->assertSame( 'create', $primary_request['body']['action'] );
 		$this->assertSame( 'post', $primary_request['body']['entity'] );
 		$this->assertSame( $post_id, $primary_request['body']['id'] );
 		$this->assertSame( 'post', $primary_request['body']['post_type'] );
 		$this->assertStringContainsString( '/wp/v2/posts/' . $post_id, $primary_request['body']['rest_url'] );
 
-		$this->assertSame( 'https://wpwf.test/secondary/post', $secondary_request['url'] );
+		$this->assertSame( $this->get_receiver_webhook_url( 'secondary-post' ), $secondary_request['url'] );
 		$this->assertSame( 'create', $secondary_request['body']['action'] );
 		$this->assertSame( $post_id, $secondary_request['body']['id'] );
 

--- a/tests/phpunit/TermWebhookCrudTest.php
+++ b/tests/phpunit/TermWebhookCrudTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Covers term lifecycle webhook behaviour.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * Verifies term webhooks dispatch stable CRUD payloads.
+ */
+final class TermWebhookCrudTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures term create, update, and delete events dispatch stable payloads.
+	 */
+	public function test_term_create_update_and_delete_webhooks(): void {
+		$term = \wp_insert_term( 'Created category', 'category' );
+
+		$this->assertIsArray( $term );
+		$this->assertArrayHasKey( 'term_id', $term );
+
+		$term_id = (int) $term['term_id'];
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'term' );
+
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'create', $actions[0]['action'] );
+		$this->assertSame( 'term', $actions[0]['entity'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'term' );
+
+		$this->assertSame( 'https://wpwf.test/primary/term', $request['url'] );
+		$this->assertSame( 'create', $request['body']['action'] );
+		$this->assertSame( 'category', $request['body']['taxonomy'] );
+		$this->assertStringContainsString( '/wp/v2/categories/' . $term_id, $request['body']['rest_url'] );
+
+		$this->reset_captured_requests();
+
+		\wp_update_term(
+			$term_id,
+			'category',
+			array(
+				'name' => 'Updated category',
+			)
+		);
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'term' );
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'update', $actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'term' );
+		$this->assertSame( 'update', $request['body']['action'] );
+		$this->assertSame( 'category', $request['body']['taxonomy'] );
+
+		$this->reset_captured_requests();
+
+		\wp_delete_term( $term_id, 'category' );
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'term' );
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'delete', $actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'term' );
+		$this->assertSame( 'delete', $request['body']['action'] );
+		$this->assertSame( 'term', $request['body']['entity'] );
+		$this->assertSame( $term_id, $request['body']['id'] );
+	}
+}

--- a/tests/phpunit/TermWebhookCrudTest.php
+++ b/tests/phpunit/TermWebhookCrudTest.php
@@ -32,7 +32,7 @@ final class TermWebhookCrudTest extends WPWF_Webhook_Test_Case {
 
 		$request = $this->get_captured_request_by_webhook_name( 'term' );
 
-		$this->assertSame( 'https://wpwf.test/primary/term', $request['url'] );
+		$this->assertSame( $this->get_receiver_webhook_url( 'primary-term' ), $request['url'] );
 		$this->assertSame( 'create', $request['body']['action'] );
 		$this->assertSame( 'category', $request['body']['taxonomy'] );
 		$this->assertStringContainsString( '/wp/v2/categories/' . $term_id, $request['body']['rest_url'] );

--- a/tests/phpunit/UserWebhookCrudTest.php
+++ b/tests/phpunit/UserWebhookCrudTest.php
@@ -16,6 +16,15 @@ final class UserWebhookCrudTest extends WPWF_Webhook_Test_Case {
 	 * Ensures user create, update, and delete events dispatch stable payloads.
 	 */
 	public function test_user_create_update_and_delete_webhooks(): void {
+		$filter_user_requests = static function ( array $requests ): array {
+			return array_values(
+				array_filter(
+					$requests,
+					static fn( array $request ): bool => 'user' === (string) ( $request['webhook_name'] ?? '' )
+				)
+			);
+		};
+
 		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'editor',
@@ -24,14 +33,23 @@ final class UserWebhookCrudTest extends WPWF_Webhook_Test_Case {
 
 		$actions = $this->get_scheduled_actions_by_webhook_name( 'user' );
 
-		$this->assertCount( 1, $actions );
-		$this->assertSame( 'create', $actions[0]['action'] );
+		$this->assertNotEmpty( $actions );
+		$this->assertContains( 'create', array_column( $actions, 'action' ) );
 
 		$this->run_scheduled_webhooks();
 
-		$request = $this->get_captured_request_by_webhook_name( 'user' );
+		$requests       = $filter_user_requests( $this->get_captured_requests() );
+		$create_request = array_values(
+			array_filter(
+				$requests,
+				static fn( array $request ): bool => 'create' === (string) ( $request['body']['action'] ?? '' )
+			)
+		);
 
-		$this->assertSame( 'https://wpwf.test/primary/user', $request['url'] );
+		$this->assertNotEmpty( $create_request );
+		$request = $create_request[0];
+
+		$this->assertSame( $this->get_receiver_webhook_url( 'primary-user' ), $request['url'] );
 		$this->assertSame( 'create', $request['body']['action'] );
 		$this->assertSame( array( 'editor' ), $request['body']['roles'] );
 		$this->assertStringContainsString( '/wp/v2/users/' . $user_id, $request['body']['rest_url'] );
@@ -46,12 +64,18 @@ final class UserWebhookCrudTest extends WPWF_Webhook_Test_Case {
 		);
 
 		$actions = $this->get_scheduled_actions_by_webhook_name( 'user' );
-		$this->assertCount( 1, $actions );
-		$this->assertSame( 'update', $actions[0]['action'] );
+		$this->assertNotEmpty( $actions );
+		$this->assertContains( 'update', array_column( $actions, 'action' ) );
 
 		$this->run_scheduled_webhooks();
 
-		$request = $this->get_captured_request_by_webhook_name( 'user' );
+		$requests = $filter_user_requests( $this->get_captured_requests() );
+		$request  = array_values(
+			array_filter(
+				$requests,
+				static fn( array $candidate ): bool => 'update' === (string) ( $candidate['body']['action'] ?? '' )
+			)
+		)[0];
 		$this->assertSame( 'update', $request['body']['action'] );
 		$this->assertSame( array( 'editor' ), $request['body']['roles'] );
 
@@ -60,12 +84,18 @@ final class UserWebhookCrudTest extends WPWF_Webhook_Test_Case {
 		\wp_delete_user( $user_id );
 
 		$actions = $this->get_scheduled_actions_by_webhook_name( 'user' );
-		$this->assertCount( 1, $actions );
-		$this->assertSame( 'delete', $actions[0]['action'] );
+		$this->assertNotEmpty( $actions );
+		$this->assertContains( 'delete', array_column( $actions, 'action' ) );
 
 		$this->run_scheduled_webhooks();
 
-		$request = $this->get_captured_request_by_webhook_name( 'user' );
+		$requests = $filter_user_requests( $this->get_captured_requests() );
+		$request  = array_values(
+			array_filter(
+				$requests,
+				static fn( array $candidate ): bool => 'delete' === (string) ( $candidate['body']['action'] ?? '' )
+			)
+		)[0];
 		$this->assertSame( 'delete', $request['body']['action'] );
 		$this->assertSame( 'user', $request['body']['entity'] );
 		$this->assertSame( $user_id, $request['body']['id'] );

--- a/tests/phpunit/UserWebhookCrudTest.php
+++ b/tests/phpunit/UserWebhookCrudTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Covers user lifecycle webhook behaviour.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * Verifies user webhooks dispatch stable CRUD payloads.
+ */
+final class UserWebhookCrudTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures user create, update, and delete events dispatch stable payloads.
+	 */
+	public function test_user_create_update_and_delete_webhooks(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'user' );
+
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'create', $actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'user' );
+
+		$this->assertSame( 'https://wpwf.test/primary/user', $request['url'] );
+		$this->assertSame( 'create', $request['body']['action'] );
+		$this->assertSame( array( 'editor' ), $request['body']['roles'] );
+		$this->assertStringContainsString( '/wp/v2/users/' . $user_id, $request['body']['rest_url'] );
+
+		$this->reset_captured_requests();
+
+		\wp_update_user(
+			array(
+				'ID'           => $user_id,
+				'display_name' => 'Updated editor',
+			)
+		);
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'user' );
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'update', $actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'user' );
+		$this->assertSame( 'update', $request['body']['action'] );
+		$this->assertSame( array( 'editor' ), $request['body']['roles'] );
+
+		$this->reset_captured_requests();
+
+		\wp_delete_user( $user_id );
+
+		$actions = $this->get_scheduled_actions_by_webhook_name( 'user' );
+		$this->assertCount( 1, $actions );
+		$this->assertSame( 'delete', $actions[0]['action'] );
+
+		$this->run_scheduled_webhooks();
+
+		$request = $this->get_captured_request_by_webhook_name( 'user' );
+		$this->assertSame( 'delete', $request['body']['action'] );
+		$this->assertSame( 'user', $request['body']['entity'] );
+		$this->assertSame( $user_id, $request['body']['id'] );
+	}
+}

--- a/tests/phpunit/WebhookFailureHandlingTest.php
+++ b/tests/phpunit/WebhookFailureHandlingTest.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Covers retries, backoff scheduling, and URL blocking behavior.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+use juvo\WP_Webhook_Framework\Failure;
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhook;
+
+/**
+ * Verifies failure handling behavior for scheduled and immediate delivery paths.
+ */
+final class WebhookFailureHandlingTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures failed scheduled deliveries queue retries with increasing retry metadata.
+	 */
+	public function test_scheduled_failures_schedule_retries_with_backoff(): void {
+		$webhook = $this->register_failure_webhook(
+			'backoff',
+			$this->get_receiver_webhook_url( 'failure-backoff', 'fail' ),
+			Delivery_Mode::SCHEDULED,
+			2,
+			99
+		);
+
+		$retry_base_filter = static function ( int $base_time, string $webhook_name, int $retry_count ) use ( $webhook ): int {
+			if ( $webhook->get_name() !== $webhook_name ) {
+				return $base_time;
+			}
+
+			return 3;
+		};
+
+		add_filter( 'wpwf_retry_base_time', $retry_base_filter, 10, 3 );
+
+		try {
+			$webhook->trigger_event( 'job-backoff' );
+
+			$initial_actions = $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() );
+			$this->assertCount( 1, $initial_actions );
+
+			$this->run_scheduled_webhooks( true );
+
+			$first_retry_actions = $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() );
+			$this->assertCount( 1, $first_retry_actions );
+			$this->assertSame( 1, (int) $first_retry_actions[0]['headers']['wpwf-retry-count'] );
+
+			$this->run_scheduled_webhooks( true );
+
+			$second_retry_actions = $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() );
+			$this->assertCount( 1, $second_retry_actions );
+			$this->assertSame( 2, (int) $second_retry_actions[0]['headers']['wpwf-retry-count'] );
+			$this->assertArrayHasKey( 'scheduled_timestamp', $first_retry_actions[0] );
+			$this->assertArrayHasKey( 'scheduled_timestamp', $second_retry_actions[0] );
+			$this->assertGreaterThan(
+				(int) $first_retry_actions[0]['scheduled_timestamp'],
+				(int) $second_retry_actions[0]['scheduled_timestamp']
+			);
+
+			$this->run_scheduled_webhooks( true );
+
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() ) );
+			$this->assertCount( 3, $this->get_captured_requests() );
+		} finally {
+			remove_filter( 'wpwf_retry_base_time', $retry_base_filter, 10 );
+		}
+	}
+
+	/**
+	 * Ensures repeated failed events block the destination URL at the configured threshold.
+	 */
+	public function test_failure_tracking_blocks_url_after_threshold(): void {
+		$webhook = $this->register_failure_webhook(
+			'blocked',
+			$this->get_receiver_webhook_url( 'failure-blocked', 'fail' ),
+			Delivery_Mode::SCHEDULED,
+			0,
+			2
+		);
+
+		$webhook->trigger_event( 'job-block-1' );
+		$this->run_scheduled_webhooks( true );
+
+		$first_state = Failure::from_transient( $webhook->get_webhook_url() );
+		$this->assertSame( 1, $first_state->get_count() );
+		$this->assertFalse( $first_state->is_blocked() );
+
+		$webhook->trigger_event( 'job-block-2' );
+		$this->run_scheduled_webhooks( true );
+
+		$second_state = Failure::from_transient( $webhook->get_webhook_url() );
+		$this->assertSame( 2, $second_state->get_count() );
+		$this->assertTrue( $second_state->is_blocked() );
+
+		$this->reset_captured_requests();
+
+		$this->run_ignoring_emit_warning(
+			static function () use ( $webhook ): void {
+				$webhook->trigger_event( 'job-block-3' );
+			}
+		);
+
+		$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() ) );
+		$this->assertCount( 0, $this->get_captured_requests() );
+	}
+
+	/**
+	 * Ensures immediate failures still queue asynchronous retries.
+	 */
+	public function test_immediate_failure_schedules_async_retry(): void {
+		$webhook = $this->register_failure_webhook(
+			'immediate',
+			$this->get_receiver_webhook_url( 'failure-immediate', 'fail' ),
+			Delivery_Mode::IMMEDIATE,
+			1,
+			99
+		);
+
+		$retry_base_filter = static function ( int $base_time, string $webhook_name, int $retry_count ) use ( $webhook ): int {
+			if ( $webhook->get_name() !== $webhook_name ) {
+				return $base_time;
+			}
+
+			return 2;
+		};
+
+		add_filter( 'wpwf_retry_base_time', $retry_base_filter, 10, 3 );
+
+		try {
+			$this->run_ignoring_emit_warning(
+				static function () use ( $webhook ): void {
+					$webhook->trigger_event( 'job-immediate-retry' );
+				}
+			);
+
+			$this->assertCount( 1, $this->get_captured_requests() );
+
+			$retry_actions = $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() );
+			$this->assertCount( 1, $retry_actions );
+			$this->assertSame( 1, (int) $retry_actions[0]['headers']['wpwf-retry-count'] );
+
+			$this->run_scheduled_webhooks( true );
+
+			$this->assertCount( 2, $this->get_captured_requests() );
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( $webhook->get_name() ) );
+		} finally {
+			remove_filter( 'wpwf_retry_base_time', $retry_base_filter, 10 );
+		}
+	}
+
+	/**
+	 * Register a failure scenario webhook with unique state and URL.
+	 *
+	 * @param string        $suffix                  Unique test suffix.
+	 * @param string        $url                     Destination URL.
+	 * @param Delivery_Mode $delivery_mode           Delivery mode under test.
+	 * @param int           $max_retries             Maximum retries.
+	 * @param int           $max_consecutive_failures Failure blocking threshold.
+	 * @return Failure_Test_Webhook
+	 */
+	private function register_failure_webhook( string $suffix, string $url, Delivery_Mode $delivery_mode, int $max_retries, int $max_consecutive_failures ): Failure_Test_Webhook {
+		$name = 'failure_test_' . $suffix . '_' . str_replace( '.', '', uniqid( '', true ) );
+
+		$webhook = new Failure_Test_Webhook( $name, $url, $delivery_mode );
+		$webhook->max_retries( $max_retries );
+		$webhook->max_consecutive_failures( $max_consecutive_failures );
+
+		Service_Provider::get_registry()->register( $webhook );
+
+		return $webhook;
+	}
+
+	/**
+	 * Execute a callback while ignoring framework warning emissions for delivery failures.
+	 *
+	 * @param callable $callback The callback to execute.
+	 */
+	private function run_ignoring_emit_warning( callable $callback ): void {
+		set_error_handler(
+			static function ( int $error_level, string $message ): bool {
+				if ( E_USER_WARNING !== $error_level ) {
+					return false;
+				}
+
+				return str_contains( $message, 'Failed to emit webhook' );
+			}
+		);
+
+		try {
+			$callback();
+		} finally {
+			restore_error_handler();
+		}
+	}
+}
+
+/**
+ * Emits fixture payloads for failure handling tests.
+ */
+final class Failure_Test_Webhook extends Webhook {
+
+	/**
+	 * Configure URL and delivery mode for this fixture webhook.
+	 *
+	 * @param string        $name          Unique webhook name.
+	 * @param string        $url           Delivery URL.
+	 * @param Delivery_Mode $delivery_mode Delivery mode under test.
+	 */
+	public function __construct( string $name, string $url, Delivery_Mode $delivery_mode ) {
+		parent::__construct( $name );
+
+		$this->webhook_url( $url );
+		$this->delivery_mode( $delivery_mode );
+	}
+
+	/**
+	 * No WordPress hooks are needed for this fixture webhook.
+	 */
+	public function init(): void {
+	}
+
+	/**
+	 * Emit a deterministic payload for assertions.
+	 *
+	 * @param string $reference Stable ID used by assertions.
+	 */
+	public function trigger_event( string $reference ): void {
+		$this->emit(
+			'trigger',
+			'failure_test',
+			$reference,
+			array(
+				'reference' => $reference,
+			)
+		);
+	}
+}

--- a/tests/phpunit/WebhookFilterTest.php
+++ b/tests/phpunit/WebhookFilterTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Covers filter-driven webhook behavior.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+
+/**
+ * Verifies runtime filters can reroute, modify, or suppress deliveries.
+ */
+final class WebhookFilterTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures payload filters can prevent scheduling entirely.
+	 */
+	public function test_payload_filter_can_prevent_custom_webhook_emission(): void {
+		$payload_filter = static function ( array $payload, string $entity, string $id ) {
+			if ( 'custom' !== $entity || 'job-filter-prevent' !== $id ) {
+				return $payload;
+			}
+
+			return false;
+		};
+
+		add_filter( 'wpwf_payload', $payload_filter, 10, 3 );
+
+		try {
+			do_action( 'wpwf_test_custom_event', 'job-filter-prevent', array( 'status' => 'queued' ) );
+
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'custom_primary' ) );
+			$this->assertCount( 0, $this->get_captured_requests() );
+		} finally {
+			remove_filter( 'wpwf_payload', $payload_filter, 10 );
+		}
+	}
+
+	/**
+	 * Ensures invalid payload filter output emits a warning and skips delivery.
+	 */
+	public function test_invalid_payload_filter_value_emits_warning(): void {
+		$payload_filter = static function ( array $payload, string $entity, string $id ) {
+			if ( 'custom' !== $entity || 'job-filter-invalid' !== $id ) {
+				return $payload;
+			}
+
+			return 'invalid';
+		};
+
+		add_filter( 'wpwf_payload', $payload_filter, 10, 3 );
+
+		$warnings = array();
+		set_error_handler(
+			static function ( int $error_level, string $message ) use ( &$warnings ): bool {
+				if ( E_USER_WARNING !== $error_level || ! str_contains( $message, 'Failed to emit webhook' ) ) {
+					return false;
+				}
+
+				$warnings[] = $message;
+				return true;
+			}
+		);
+
+		try {
+			do_action( 'wpwf_test_custom_event', 'job-filter-invalid', array( 'status' => 'queued' ) );
+
+			$this->assertCount( 1, $warnings );
+			$this->assertStringContainsString( 'webhook_payload_invalid', $warnings[0] );
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'custom_primary' ) );
+			$this->assertCount( 0, $this->get_captured_requests() );
+		} finally {
+			restore_error_handler();
+			remove_filter( 'wpwf_payload', $payload_filter, 10 );
+		}
+	}
+
+	/**
+	 * Ensures delivery mode can be forced to immediate at runtime.
+	 */
+	public function test_delivery_mode_filter_can_force_immediate_delivery(): void {
+		$delivery_mode_filter = static function ( string $delivery_mode, string $webhook_name ): string {
+			if ( 'custom_primary' !== $webhook_name ) {
+				return $delivery_mode;
+			}
+
+			return Delivery_Mode::IMMEDIATE->value;
+		};
+
+		add_filter( 'wpwf_delivery_mode', $delivery_mode_filter, 10, 2 );
+
+		try {
+			do_action( 'wpwf_test_custom_event', 'job-filter-immediate', array( 'status' => 'queued' ) );
+
+			$this->assertCount( 1, $this->get_captured_requests() );
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'custom_primary' ) );
+		} finally {
+			remove_filter( 'wpwf_delivery_mode', $delivery_mode_filter, 10 );
+		}
+	}
+
+	/**
+	 * Ensures URL, body, and header filters are applied to outgoing requests.
+	 */
+	public function test_request_filters_modify_routed_delivery(): void {
+		$url_filter = function ( string $url, string $entity, string $id ): string {
+			if ( 'custom' !== $entity || 'job-filter-routed' !== $id ) {
+				return $url;
+			}
+
+			return $this->get_receiver_webhook_url( 'filtered-custom-route' );
+		};
+
+		$body_filter = static function ( array $body, string $action, string $entity, string $id ): array {
+			if ( 'custom' !== $entity || 'job-filter-routed' !== $id ) {
+				return $body;
+			}
+
+			$body['filtered'] = 'yes';
+			return $body;
+		};
+
+		$headers_filter = static function ( array $headers, string $entity, string $id, $webhook ): array {
+			if ( 'custom_primary' !== $webhook->get_name() || 'job-filter-routed' !== $id ) {
+				return $headers;
+			}
+
+			$headers['X-Test-Header'] = 'filter-applied';
+			return $headers;
+		};
+
+		add_filter( 'wpwf_url', $url_filter, 10, 3 );
+		add_filter( 'wpwf_request_body', $body_filter, 10, 6 );
+		add_filter( 'wpwf_headers', $headers_filter, 10, 4 );
+
+		try {
+			do_action( 'wpwf_test_custom_event', 'job-filter-routed', array( 'status' => 'queued' ) );
+
+			$this->assertCount( 1, $this->get_scheduled_actions_by_webhook_name( 'custom_primary' ) );
+
+			$this->run_scheduled_webhooks();
+
+			$request = $this->get_captured_request_by_webhook_name( 'custom_primary' );
+			$this->assertSame( $this->get_receiver_webhook_url( 'filtered-custom-route' ), $request['url'] );
+			$this->assertSame( 'yes', $request['body']['filtered'] );
+			$this->assertSame( 'filter-applied', $request['headers']['x-test-header'] );
+		} finally {
+			remove_filter( 'wpwf_url', $url_filter, 10 );
+			remove_filter( 'wpwf_request_body', $body_filter, 10 );
+			remove_filter( 'wpwf_headers', $headers_filter, 10 );
+		}
+	}
+
+	/**
+	 * Ensures meta exclusion filters can suppress otherwise valid meta changes.
+	 */
+	public function test_excluded_meta_filter_can_skip_public_meta_updates(): void {
+		$excluded_meta_filter = static function ( bool $excluded, string $meta_key, string $meta_type, int $object_id ): bool {
+			if ( 'post' !== $meta_type || 'skip_me' !== $meta_key || 1 > $object_id ) {
+				return $excluded;
+			}
+
+			return true;
+		};
+
+		add_filter( 'wpwf_excluded_meta', $excluded_meta_filter, 10, 4 );
+
+		try {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_title' => 'Excluded meta post',
+				)
+			);
+
+			add_post_meta( $post_id, 'skip_me', 'before', true );
+			$this->clear_scheduled_webhooks();
+			$this->reset_captured_requests();
+
+			update_post_meta( $post_id, 'skip_me', 'after' );
+
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'meta' ) );
+			$this->assertCount( 0, $this->get_scheduled_actions_by_webhook_name( 'post' ) );
+			$this->assertCount( 0, $this->get_captured_requests() );
+		} finally {
+			remove_filter( 'wpwf_excluded_meta', $excluded_meta_filter, 10 );
+		}
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -32,6 +32,7 @@ require_once $tests_dir . '/includes/functions.php';
 function wpwf_load_fixture_plugins(): void {
 	$wp_content_dir = dirname( __DIR__, 3 );
 
+	require_once $wp_content_dir . '/mu-plugins/wpwf-test-receiver.php';
 	require_once $wp_content_dir . '/plugins/wpwf-test-app/wpwf-test-app.php';
 	require_once $wp_content_dir . '/plugins/wpwf-test-secondary/wpwf-test-secondary.php';
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Bootstraps the wp-env WordPress PHPUnit suite.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+$tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( false === $tests_dir || '' === $tests_dir ) {
+	$tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once dirname( __DIR__, 2 ) . '/vendor/autoload.php';
+
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills' );
+}
+
+require_once $tests_dir . '/includes/functions.php';
+
+/**
+ * Loads the fixture plugin entrypoints for the WordPress test bootstrap.
+ *
+ * The `plugins` setting in `.wp-env.json` activates both fixtures on the
+ * development site, but the core PHPUnit bootstrap uses its own install.
+ * Loading the plugin files here keeps the plugin-owned framework boot logic
+ * intact while matching that isolated test runtime.
+ */
+function wpwf_load_fixture_plugins(): void {
+	$wp_content_dir = dirname( __DIR__, 3 );
+
+	require_once $wp_content_dir . '/plugins/wpwf-test-app/wpwf-test-app.php';
+	require_once $wp_content_dir . '/plugins/wpwf-test-secondary/wpwf-test-secondary.php';
+}
+
+call_user_func( 'tests_add_filter', 'muplugins_loaded', 'wpwf_load_fixture_plugins' );
+
+require_once $tests_dir . '/includes/bootstrap.php';
+require_once __DIR__ . '/includes/class-wpwf-webhook-test-case.php';

--- a/tests/phpunit/includes/class-wpwf-webhook-test-case.php
+++ b/tests/phpunit/includes/class-wpwf-webhook-test-case.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Shared helpers for exercising webhook scheduling and delivery.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+/**
+ * Provides stable assertions around scheduled actions and dispatched payloads.
+ */
+abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
+
+	/**
+	 * Captured webhook requests for the current test.
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	protected static array $captured_requests = array();
+
+	/**
+	 * Resets the queue state before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once \ABSPATH . 'wp-admin/includes/user.php';
+
+		self::$captured_requests = array();
+		$this->clear_scheduled_webhooks();
+
+		\add_filter( 'pre_http_request', array( static::class, 'capture_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Removes test filters and queued work after each test.
+	 */
+	public function tear_down(): void {
+		\remove_filter( 'pre_http_request', array( static::class, 'capture_http_request' ), 10 );
+
+		$this->clear_scheduled_webhooks();
+		self::$captured_requests = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Captures fixture webhook requests and short-circuits remote transport.
+	 *
+	 * @param mixed                $preempt Existing preempt value.
+	 * @param array<string,mixed>  $args    Parsed request arguments.
+	 * @param string               $url     Request URL.
+	 * @return mixed
+	 */
+	public static function capture_http_request( $preempt, array $args, string $url ) {
+		if ( ! str_starts_with( $url, 'https://wpwf.test/' ) ) {
+			return $preempt;
+		}
+
+		$body = array();
+		if ( isset( $args['body'] ) && is_string( $args['body'] ) ) {
+			$decoded_body = json_decode( $args['body'], true );
+			if ( is_array( $decoded_body ) ) {
+				$body = $decoded_body;
+			}
+		}
+
+		self::$captured_requests[] = array(
+			'url'          => $url,
+			'args'         => $args,
+			'body'         => $body,
+			'webhook_name' => is_array( $args['headers'] ?? null ) ? (string) ( $args['headers']['wpwf-webhook-name'] ?? '' ) : '',
+		);
+
+		return array(
+			'headers'  => array(),
+			'body'     => '{}',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Returns scheduled webhook actions keyed by Action Scheduler arguments.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected function get_scheduled_webhook_actions(): array {
+		$actions = array();
+		$store   = $this->get_action_store();
+
+		$action_ids = \as_get_scheduled_actions(
+			array(
+				'hook'    => 'wpwf_send_webhook',
+				'status'  => \ActionScheduler_Store::STATUS_PENDING,
+				'orderby' => 'date',
+				'order'   => 'ASC',
+				'per_page' => 100,
+			),
+			'ids'
+		);
+
+		foreach ( $action_ids as $action_id ) {
+			$action = $store->fetch_action( $action_id );
+			$args   = $action->get_args();
+
+			if ( ! is_array( $args ) ) {
+				continue;
+			}
+
+			$args['action_id'] = $action_id;
+			$actions[]         = $args;
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Returns scheduled webhook actions for a single webhook name.
+	 *
+	 * @param string $webhook_name The webhook identifier.
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected function get_scheduled_actions_by_webhook_name( string $webhook_name ): array {
+		$matches = array();
+
+		foreach ( $this->get_scheduled_webhook_actions() as $action ) {
+			$headers = $action['headers'] ?? array();
+			$name    = is_array( $headers ) ? (string) ( $headers['wpwf-webhook-name'] ?? '' ) : '';
+
+			if ( $webhook_name !== $name ) {
+				continue;
+			}
+
+			$matches[] = $action;
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Executes all queued framework webhook actions immediately.
+	 */
+	protected function run_scheduled_webhooks(): void {
+		$actions = $this->get_scheduled_webhook_actions();
+		$store   = $this->get_action_store();
+
+		foreach ( $actions as $action ) {
+			$action_id = (int) $action['action_id'];
+			$stored_action = $store->fetch_action( $action_id );
+			$stored_action->execute();
+			$store->mark_complete( $action_id );
+			$store->delete_action( $action_id );
+		}
+	}
+
+	/**
+	 * Removes all queued framework webhook actions.
+	 */
+	protected function clear_scheduled_webhooks(): void {
+		$store      = $this->get_action_store();
+		$action_ids = \as_get_scheduled_actions(
+			array(
+				'hook'     => 'wpwf_send_webhook',
+				'orderby'  => 'date',
+				'order'    => 'ASC',
+				'per_page' => 100,
+			),
+			'ids'
+		);
+
+		foreach ( $action_ids as $action_id ) {
+			$store->delete_action( $action_id );
+		}
+	}
+
+	/**
+	 * Resolves the Action Scheduler store used by fixture actions.
+	 *
+	 * @return object
+	 */
+	private function get_action_store() {
+		$store = \ActionScheduler::store();
+
+		if ( $store instanceof \ActionScheduler_HybridStore ) {
+			return new \ActionScheduler_DBStore();
+		}
+
+		return $store;
+	}
+
+	/**
+	 * Clears captured webhook requests between assertion phases.
+	 */
+	protected function reset_captured_requests(): void {
+		self::$captured_requests = array();
+	}
+
+	/**
+	 * Returns all intercepted requests for the current test.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	protected function get_captured_requests(): array {
+		return self::$captured_requests;
+	}
+
+	/**
+	 * Returns the first captured request for a webhook name.
+	 *
+	 * @param string $webhook_name The webhook identifier.
+	 * @return array<string,mixed>
+	 */
+	protected function get_captured_request_by_webhook_name( string $webhook_name ): array {
+		foreach ( self::$captured_requests as $request ) {
+			if ( $webhook_name === $request['webhook_name'] ) {
+				return $request;
+			}
+		}
+
+		$this->fail( sprintf( 'Failed to capture a request for webhook "%s".', $webhook_name ) );
+
+		return array();
+	}
+}

--- a/tests/phpunit/includes/class-wpwf-webhook-test-case.php
+++ b/tests/phpunit/includes/class-wpwf-webhook-test-case.php
@@ -13,76 +13,50 @@ declare(strict_types=1);
 abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 
 	/**
-	 * Captured webhook requests for the current test.
-	 *
-	 * @var array<int,array<string,mixed>>
-	 */
-	protected static array $captured_requests = array();
-
-	/**
-	 * Resets the queue state before each test.
+	 * Prepare a clean queue and receiver state before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
 
 		require_once \ABSPATH . 'wp-admin/includes/user.php';
 
-		self::$captured_requests = array();
 		$this->clear_scheduled_webhooks();
-
-		\add_filter( 'pre_http_request', array( static::class, 'capture_http_request' ), 10, 3 );
+		$this->reset_receiver_logs( true );
 	}
 
 	/**
-	 * Removes test filters and queued work after each test.
+	 * Remove queued actions and captured receiver logs after each test.
 	 */
 	public function tear_down(): void {
-		\remove_filter( 'pre_http_request', array( static::class, 'capture_http_request' ), 10 );
-
 		$this->clear_scheduled_webhooks();
-		self::$captured_requests = array();
+		$this->reset_receiver_logs( false );
 
 		parent::tear_down();
 	}
 
 	/**
-	 * Captures fixture webhook requests and short-circuits remote transport.
+	 * Resolve the receiver base URL used by fixture webhook senders.
 	 *
-	 * @param mixed                $preempt Existing preempt value.
-	 * @param array<string,mixed>  $args    Parsed request arguments.
-	 * @param string               $url     Request URL.
-	 * @return mixed
+	 * @return string
 	 */
-	public static function capture_http_request( $preempt, array $args, string $url ) {
-		if ( ! str_starts_with( $url, 'https://wpwf.test/' ) ) {
-			return $preempt;
+	protected function get_receiver_base_url(): string {
+		$base_url = getenv( 'WPWF_TEST_RECEIVER_BASE_URL' );
+		if ( ! is_string( $base_url ) || '' === $base_url ) {
+			$base_url = 'http://wordpress';
 		}
 
-		$body = array();
-		if ( isset( $args['body'] ) && is_string( $args['body'] ) ) {
-			$decoded_body = json_decode( $args['body'], true );
-			if ( is_array( $decoded_body ) ) {
-				$body = $decoded_body;
-			}
-		}
+		return \untrailingslashit( $base_url );
+	}
 
-		self::$captured_requests[] = array(
-			'url'          => $url,
-			'args'         => $args,
-			'body'         => $body,
-			'webhook_name' => is_array( $args['headers'] ?? null ) ? (string) ( $args['headers']['wpwf-webhook-name'] ?? '' ) : '',
-		);
-
-		return array(
-			'headers'  => array(),
-			'body'     => '{}',
-			'response' => array(
-				'code'    => 200,
-				'message' => 'OK',
-			),
-			'cookies'  => array(),
-			'filename' => null,
-		);
+	/**
+	 * Build a fixture receiver webhook URL.
+	 *
+	 * @param string $target Receiver target identifier.
+	 * @param string $mode   Receiver mode (`success` or `fail`).
+	 * @return string
+	 */
+	protected function get_receiver_webhook_url( string $target, string $mode = 'success' ): string {
+		return $this->get_receiver_base_url() . '/index.php?rest_route=/wpwf-test/v1/receive/' . rawurlencode( $mode ) . '/' . rawurlencode( $target );
 	}
 
 	/**
@@ -96,10 +70,10 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 
 		$action_ids = \as_get_scheduled_actions(
 			array(
-				'hook'    => 'wpwf_send_webhook',
-				'status'  => \ActionScheduler_Store::STATUS_PENDING,
-				'orderby' => 'date',
-				'order'   => 'ASC',
+				'hook'     => 'wpwf_send_webhook',
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'orderby'  => 'date',
+				'order'    => 'ASC',
 				'per_page' => 100,
 			),
 			'ids'
@@ -111,6 +85,14 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 
 			if ( ! is_array( $args ) ) {
 				continue;
+			}
+
+			$schedule = $action->get_schedule();
+			if ( is_object( $schedule ) && method_exists( $schedule, 'get_date' ) ) {
+				$date = $schedule->get_date();
+				if ( $date instanceof \DateTimeInterface ) {
+					$args['scheduled_timestamp'] = $date->getTimestamp();
+				}
 			}
 
 			$args['action_id'] = $action_id;
@@ -145,17 +127,31 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 
 	/**
 	 * Executes all queued framework webhook actions immediately.
+	 *
+	 * @param bool $allow_failures Whether delivery failures should be swallowed.
 	 */
-	protected function run_scheduled_webhooks(): void {
+	protected function run_scheduled_webhooks( bool $allow_failures = false ): void {
 		$actions = $this->get_scheduled_webhook_actions();
 		$store   = $this->get_action_store();
 
 		foreach ( $actions as $action ) {
-			$action_id = (int) $action['action_id'];
-			$stored_action = $store->fetch_action( $action_id );
-			$stored_action->execute();
-			$store->mark_complete( $action_id );
-			$store->delete_action( $action_id );
+			$action_id      = (int) $action['action_id'];
+			$stored_action  = $store->fetch_action( $action_id );
+
+			try {
+				$stored_action->execute();
+				$store->mark_complete( $action_id );
+			} catch ( \Throwable $throwable ) {
+				if ( method_exists( $store, 'mark_failure' ) ) {
+					$store->mark_failure( $action_id );
+				}
+
+				if ( ! $allow_failures ) {
+					throw $throwable;
+				}
+			} finally {
+				$store->delete_action( $action_id );
+			}
 		}
 	}
 
@@ -198,7 +194,7 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 	 * Clears captured webhook requests between assertion phases.
 	 */
 	protected function reset_captured_requests(): void {
-		self::$captured_requests = array();
+		$this->reset_receiver_logs( true );
 	}
 
 	/**
@@ -207,7 +203,7 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 	 * @return array<int,array<string,mixed>>
 	 */
 	protected function get_captured_requests(): array {
-		return self::$captured_requests;
+		return $this->get_receiver_logs();
 	}
 
 	/**
@@ -217,8 +213,8 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 	 * @return array<string,mixed>
 	 */
 	protected function get_captured_request_by_webhook_name( string $webhook_name ): array {
-		foreach ( self::$captured_requests as $request ) {
-			if ( $webhook_name === $request['webhook_name'] ) {
+		foreach ( $this->get_receiver_logs() as $request ) {
+			if ( $webhook_name === (string) ( $request['webhook_name'] ?? '' ) ) {
 				return $request;
 			}
 		}
@@ -226,5 +222,82 @@ abstract class WPWF_Webhook_Test_Case extends WP_UnitTestCase {
 		$this->fail( sprintf( 'Failed to capture a request for webhook "%s".', $webhook_name ) );
 
 		return array();
+	}
+
+	/**
+	 * Retrieve webhook request logs from the receiver fixture API.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function get_receiver_logs(): array {
+		$response = \wp_remote_post(
+			$this->get_receiver_logs_url(),
+			array(
+				'timeout' => 10,
+			)
+		);
+
+		if ( \is_wp_error( $response ) ) {
+			$this->fail( 'Failed to load receiver logs: ' . $response->get_error_message() );
+			return array();
+		}
+
+		$status_code = (int) \wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $status_code ) {
+			$this->fail( sprintf( 'Failed to load receiver logs. Status code: %d.', $status_code ) );
+			return array();
+		}
+
+		$decoded = json_decode( (string) \wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $decoded ) || ! isset( $decoded['logs'] ) || ! is_array( $decoded['logs'] ) ) {
+			$this->fail( 'Receiver returned invalid logs response.' );
+			return array();
+		}
+
+		return array_values( $decoded['logs'] );
+	}
+
+	/**
+	 * Reset receiver logs through the fixture API.
+	 *
+	 * @param bool $strict Whether failures should fail the current test.
+	 */
+	private function reset_receiver_logs( bool $strict ): void {
+		$response = \wp_remote_post(
+			$this->get_receiver_reset_url(),
+			array(
+				'timeout' => 10,
+			)
+		);
+
+		if ( \is_wp_error( $response ) ) {
+			if ( $strict ) {
+				$this->fail( 'Failed to reset receiver logs: ' . $response->get_error_message() );
+			}
+			return;
+		}
+
+		$status_code = (int) \wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $status_code && $strict ) {
+			$this->fail( sprintf( 'Failed to reset receiver logs. Status code: %d.', $status_code ) );
+		}
+	}
+
+	/**
+	 * Build the receiver logs endpoint URL.
+	 *
+	 * @return string
+	 */
+	private function get_receiver_logs_url(): string {
+		return $this->get_receiver_base_url() . '/index.php?rest_route=/wpwf-test/v1/logs';
+	}
+
+	/**
+	 * Build the receiver logs reset endpoint URL.
+	 *
+	 * @return string
+	 */
+	private function get_receiver_reset_url(): string {
+		return $this->get_receiver_base_url() . '/index.php?rest_route=/wpwf-test/v1/logs/reset';
 	}
 }

--- a/tests/wp-env/mu-plugins/wpwf-test-receiver.php
+++ b/tests/wp-env/mu-plugins/wpwf-test-receiver.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Plugin Name: WPWF Test Receiver (MU)
+ * Description: Receives and stores webhook requests for wp-env integration tests.
+ * Version: 1.0.0
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+namespace juvo\WP_Webhook_Framework\Tests\Fixtures\Receiver;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Option key used to persist captured webhook requests.
+ */
+const RECEIVER_LOG_OPTION_KEY = 'wpwf_test_receiver_logs';
+
+/**
+ * Resolve the base URL used by fixture webhook senders.
+ *
+ * @return string
+ */
+function receiver_base_url(): string {
+	$base_url = getenv( 'WPWF_TEST_RECEIVER_BASE_URL' );
+	if ( ! is_string( $base_url ) || '' === $base_url ) {
+		$base_url = 'http://wordpress';
+	}
+
+	return untrailingslashit( $base_url );
+}
+
+/**
+ * Register receiver management and delivery routes.
+ */
+function register_routes(): void {
+	register_rest_route(
+		'wpwf-test/v1',
+		'/receive/(?P<mode>success|fail)/(?P<target>[a-z0-9_-]+)',
+		array(
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\receive_webhook',
+			'permission_callback' => '__return_true',
+		)
+	);
+
+	register_rest_route(
+		'wpwf-test/v1',
+		'/logs',
+		array(
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\list_logs',
+			'permission_callback' => '__return_true',
+		)
+	);
+
+	register_rest_route(
+		'wpwf-test/v1',
+		'/logs/reset',
+		array(
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\reset_logs',
+			'permission_callback' => '__return_true',
+		)
+	);
+}
+
+/**
+ * Capture a delivered webhook payload and return a configured status response.
+ *
+ * @param WP_REST_Request $request The incoming REST request.
+ * @return WP_REST_Response
+ */
+function receive_webhook( WP_REST_Request $request ): WP_REST_Response {
+	$mode   = (string) $request->get_param( 'mode' );
+	$target = (string) $request->get_param( 'target' );
+
+	$raw_body = $request->get_body();
+	$body     = json_decode( $raw_body, true );
+	if ( ! is_array( $body ) ) {
+		$body = array();
+	}
+
+	$headers      = normalize_headers( $request->get_headers() );
+	$webhook_name = (string) ( $headers['wpwf-webhook-name'] ?? '' );
+
+	$logs   = get_logs();
+	$logs[] = array(
+		'url'          => receiver_base_url() . '/index.php?rest_route=' . $request->get_route(),
+		'mode'         => $mode,
+		'target'       => $target,
+		'webhook_name' => $webhook_name,
+		'headers'      => $headers,
+		'body'         => $body,
+		'raw_body'     => $raw_body,
+		'timestamp'    => time(),
+	);
+
+	save_logs( $logs );
+
+	$status_code = 'fail' === $mode ? 500 : 200;
+
+	return new WP_REST_Response(
+		array(
+			'mode'     => $mode,
+			'target'   => $target,
+			'received' => true,
+		),
+		$status_code
+	);
+}
+
+/**
+ * Return all captured webhook requests.
+ *
+ * @return WP_REST_Response
+ */
+function list_logs(): WP_REST_Response {
+	return new WP_REST_Response(
+		array(
+			'logs' => get_logs(),
+		)
+	);
+}
+
+/**
+ * Reset captured webhook requests.
+ *
+ * @return WP_REST_Response
+ */
+function reset_logs(): WP_REST_Response {
+	save_logs( array() );
+
+	return new WP_REST_Response(
+		array(
+			'logs' => array(),
+		)
+	);
+}
+
+/**
+ * Retrieve persisted webhook logs.
+ *
+ * @return array<int,array<string,mixed>>
+ */
+function get_logs(): array {
+	$logs = get_option( RECEIVER_LOG_OPTION_KEY, array() );
+
+	if ( ! is_array( $logs ) ) {
+		return array();
+	}
+
+	return array_values( $logs );
+}
+
+/**
+ * Persist webhook logs for later assertions.
+ *
+ * @param array<int,array<string,mixed>> $logs The logs to store.
+ */
+function save_logs( array $logs ): void {
+	update_option( RECEIVER_LOG_OPTION_KEY, $logs, false );
+}
+
+/**
+ * Normalize WordPress REST header lists into scalar string values.
+ *
+ * @param array<string,mixed> $headers Raw headers from WP_REST_Request.
+ * @return array<string,string>
+ */
+function normalize_headers( array $headers ): array {
+	$normalized = array();
+
+	foreach ( $headers as $key => $value ) {
+		$normalized_key = strtolower( str_replace( '_', '-', $key ) );
+
+		if ( is_array( $value ) ) {
+			$first_value         = array_shift( $value );
+			$normalized[ $normalized_key ] = is_scalar( $first_value ) ? (string) $first_value : '';
+			continue;
+		}
+
+		$normalized[ $normalized_key ] = is_scalar( $value ) ? (string) $value : '';
+	}
+
+	return $normalized;
+}
+
+add_action( 'rest_api_init', __NAMESPACE__ . '\\register_routes' );

--- a/tests/wp-env/plugins/wpwf-test-app/wpwf-test-app.php
+++ b/tests/wp-env/plugins/wpwf-test-app/wpwf-test-app.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Plugin Name: WPWF Test App
+ * Description: Registers primary fixture webhooks for wp-env application tests.
+ * Version: 1.0.0
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+namespace juvo\WP_Webhook_Framework\Tests\Fixtures\App;
+
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhook;
+use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
+use juvo\WP_Webhook_Framework\Webhooks\Term_Webhook;
+use juvo\WP_Webhook_Framework\Webhooks\User_Webhook;
+
+$wp_content_dir        = dirname( __DIR__, 2 );
+$autoload_path         = $wp_content_dir . '/wpwf-framework/vendor/autoload.php';
+$action_scheduler_path = $wp_content_dir . '/wpwf-framework/vendor/woocommerce/action-scheduler/action-scheduler.php';
+
+if ( ! file_exists( $autoload_path ) ) {
+	return;
+}
+
+require_once $autoload_path;
+
+require_once $action_scheduler_path;
+
+Service_Provider::register();
+
+/**
+ * Emits a custom test event so application-level integrations can be validated.
+ */
+final class Custom_Primary_Webhook extends Webhook {
+
+	/**
+	 * Configures the fixture webhook endpoint.
+	 */
+	public function __construct() {
+		parent::__construct( 'custom_primary' );
+		$this->webhook_url( 'https://wpwf.test/primary/custom' );
+	}
+
+	/**
+	 * Hooks the fixture event into the framework.
+	 */
+	public function init(): void {
+		\add_action( 'wpwf_test_custom_event', array( $this, 'on_custom_event' ), 10, 2 );
+	}
+
+	/**
+	 * Schedules a custom webhook payload for the current fixture event.
+	 *
+	 * @param string              $reference The fixture event identifier.
+	 * @param array<string,mixed> $context   Extra event metadata.
+	 */
+	public function on_custom_event( string $reference, array $context = array() ): void {
+		$this->emit(
+			'trigger',
+			'custom',
+			$reference,
+			array(
+				'reference' => $reference,
+				'context'   => $context,
+			)
+		);
+	}
+}
+
+/**
+ * Registers the primary built-in and custom fixture webhooks.
+ *
+ * @param Webhook_Registry $registry The framework registry.
+ */
+function register_test_webhooks( Webhook_Registry $registry ): void {
+	$post_webhook = new Post_Webhook();
+	$post_webhook->webhook_url( 'https://wpwf.test/primary/post' );
+	$registry->register( $post_webhook );
+
+	$term_webhook = new Term_Webhook();
+	$term_webhook->webhook_url( 'https://wpwf.test/primary/term' );
+	$registry->register( $term_webhook );
+
+	$user_webhook = new User_Webhook();
+	$user_webhook->webhook_url( 'https://wpwf.test/primary/user' );
+	$registry->register( $user_webhook );
+
+	$registry->register( new Custom_Primary_Webhook() );
+}
+
+\add_action( 'wpwf_register_webhooks', __NAMESPACE__ . '\\register_test_webhooks' );

--- a/tests/wp-env/plugins/wpwf-test-app/wpwf-test-app.php
+++ b/tests/wp-env/plugins/wpwf-test-app/wpwf-test-app.php
@@ -14,6 +14,8 @@ namespace juvo\WP_Webhook_Framework\Tests\Fixtures\App;
 use juvo\WP_Webhook_Framework\Service_Provider;
 use juvo\WP_Webhook_Framework\Webhook;
 use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Emission_Mode;
+use juvo\WP_Webhook_Framework\Webhooks\Meta_Webhook;
 use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
 use juvo\WP_Webhook_Framework\Webhooks\Term_Webhook;
 use juvo\WP_Webhook_Framework\Webhooks\User_Webhook;
@@ -33,6 +35,31 @@ require_once $action_scheduler_path;
 Service_Provider::register();
 
 /**
+ * Resolve the shared receiver base URL used by integration fixtures.
+ *
+ * @return string
+ */
+function receiver_base_url(): string {
+	$base_url = getenv( 'WPWF_TEST_RECEIVER_BASE_URL' );
+	if ( ! is_string( $base_url ) || '' === $base_url ) {
+		$base_url = 'http://wordpress';
+	}
+
+	return \untrailingslashit( $base_url );
+}
+
+/**
+ * Build a receiver endpoint URL for fixture webhook delivery.
+ *
+ * @param string $target Receiver target identifier.
+ * @param string $mode   Receiver mode (`success` or `fail`).
+ * @return string
+ */
+function receiver_webhook_url( string $target, string $mode = 'success' ): string {
+	return receiver_base_url() . '/index.php?rest_route=/wpwf-test/v1/receive/' . rawurlencode( $mode ) . '/' . rawurlencode( $target );
+}
+
+/**
  * Emits a custom test event so application-level integrations can be validated.
  */
 final class Custom_Primary_Webhook extends Webhook {
@@ -42,7 +69,7 @@ final class Custom_Primary_Webhook extends Webhook {
 	 */
 	public function __construct() {
 		parent::__construct( 'custom_primary' );
-		$this->webhook_url( 'https://wpwf.test/primary/custom' );
+		$this->webhook_url( receiver_webhook_url( 'primary-custom' ) );
 	}
 
 	/**
@@ -72,24 +99,69 @@ final class Custom_Primary_Webhook extends Webhook {
 }
 
 /**
+ * Emits a fixture webhook with blocked notifications enabled.
+ */
+final class Notification_Primary_Webhook extends Webhook {
+
+	/**
+	 * Configures the fixture webhook endpoint and notifications.
+	 */
+	public function __construct() {
+		parent::__construct( 'custom_blocked_notification' );
+		$this->webhook_url( receiver_webhook_url( 'primary-notification' ) );
+		$this->max_consecutive_failures( 1 );
+		$this->notifications( array( 'blocked' ) );
+	}
+
+	/**
+	 * Hooks the fixture event into the framework.
+	 */
+	public function init(): void {
+		\add_action( 'wpwf_test_notification_event', array( $this, 'on_notification_event' ), 10, 1 );
+	}
+
+	/**
+	 * Schedules a payload that can be forced into a blocked state by tests.
+	 *
+	 * @param string $reference The fixture event identifier.
+	 */
+	public function on_notification_event( string $reference ): void {
+		$this->emit(
+			'trigger',
+			'notification',
+			$reference,
+			array(
+				'reference' => $reference,
+			)
+		);
+	}
+}
+
+/**
  * Registers the primary built-in and custom fixture webhooks.
  *
  * @param Webhook_Registry $registry The framework registry.
  */
 function register_test_webhooks( Webhook_Registry $registry ): void {
 	$post_webhook = new Post_Webhook();
-	$post_webhook->webhook_url( 'https://wpwf.test/primary/post' );
+	$post_webhook->webhook_url( receiver_webhook_url( 'primary-post' ) );
 	$registry->register( $post_webhook );
 
 	$term_webhook = new Term_Webhook();
-	$term_webhook->webhook_url( 'https://wpwf.test/primary/term' );
+	$term_webhook->webhook_url( receiver_webhook_url( 'primary-term' ) );
 	$registry->register( $term_webhook );
 
 	$user_webhook = new User_Webhook();
-	$user_webhook->webhook_url( 'https://wpwf.test/primary/user' );
+	$user_webhook->webhook_url( receiver_webhook_url( 'primary-user' ) );
 	$registry->register( $user_webhook );
 
+	$meta_webhook = new Meta_Webhook();
+	$meta_webhook->webhook_url( receiver_webhook_url( 'primary-meta' ) );
+	$meta_webhook->emission_mode( Meta_Emission_Mode::META );
+	$registry->register( $meta_webhook );
+
 	$registry->register( new Custom_Primary_Webhook() );
+	$registry->register( new Notification_Primary_Webhook() );
 }
 
 \add_action( 'wpwf_register_webhooks', __NAMESPACE__ . '\\register_test_webhooks' );

--- a/tests/wp-env/plugins/wpwf-test-secondary/wpwf-test-secondary.php
+++ b/tests/wp-env/plugins/wpwf-test-secondary/wpwf-test-secondary.php
@@ -30,13 +30,38 @@ require_once $action_scheduler_path;
 Service_Provider::register();
 
 /**
+ * Resolve the shared receiver base URL used by integration fixtures.
+ *
+ * @return string
+ */
+function receiver_base_url(): string {
+	$base_url = getenv( 'WPWF_TEST_RECEIVER_BASE_URL' );
+	if ( ! is_string( $base_url ) || '' === $base_url ) {
+		$base_url = 'http://wordpress';
+	}
+
+	return \untrailingslashit( $base_url );
+}
+
+/**
+ * Build a receiver endpoint URL for fixture webhook delivery.
+ *
+ * @param string $target Receiver target identifier.
+ * @param string $mode   Receiver mode (`success` or `fail`).
+ * @return string
+ */
+function receiver_webhook_url( string $target, string $mode = 'success' ): string {
+	return receiver_base_url() . '/index.php?rest_route=/wpwf-test/v1/receive/' . rawurlencode( $mode ) . '/' . rawurlencode( $target );
+}
+
+/**
  * Registers a second post webhook from another plugin namespace.
  *
  * @param Webhook_Registry $registry The framework registry.
  */
 function register_secondary_webhooks( Webhook_Registry $registry ): void {
 	$post_webhook = new Post_Webhook( 'post_secondary' );
-	$post_webhook->webhook_url( 'https://wpwf.test/secondary/post' );
+	$post_webhook->webhook_url( receiver_webhook_url( 'secondary-post' ) );
 
 	$registry->register( $post_webhook );
 }

--- a/tests/wp-env/plugins/wpwf-test-secondary/wpwf-test-secondary.php
+++ b/tests/wp-env/plugins/wpwf-test-secondary/wpwf-test-secondary.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Plugin Name: WPWF Test Secondary
+ * Description: Registers a secondary consumer webhook for multi-plugin validation.
+ * Version: 1.0.0
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+namespace juvo\WP_Webhook_Framework\Tests\Fixtures\Secondary;
+
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Webhooks\Post_Webhook;
+
+$wp_content_dir        = dirname( __DIR__, 2 );
+$autoload_path         = $wp_content_dir . '/wpwf-framework/vendor/autoload.php';
+$action_scheduler_path = $wp_content_dir . '/wpwf-framework/vendor/woocommerce/action-scheduler/action-scheduler.php';
+
+if ( ! file_exists( $autoload_path ) ) {
+	return;
+}
+
+require_once $autoload_path;
+
+require_once $action_scheduler_path;
+
+Service_Provider::register();
+
+/**
+ * Registers a second post webhook from another plugin namespace.
+ *
+ * @param Webhook_Registry $registry The framework registry.
+ */
+function register_secondary_webhooks( Webhook_Registry $registry ): void {
+	$post_webhook = new Post_Webhook( 'post_secondary' );
+	$post_webhook->webhook_url( 'https://wpwf.test/secondary/post' );
+
+	$registry->register( $post_webhook );
+}
+
+\add_action( 'wpwf_register_webhooks', __NAMESPACE__ . '\\register_secondary_webhooks' );


### PR DESCRIPTION
## Summary
- expand the wp-env application test harness with a real HTTP receiver, plus coverage for delivery modes, meta flows, runtime filters, blocked notifications, and failure-window recovery
- fix framework behavior uncovered by the new application tests, including notification initialization order, single-init notification hooks, expired block reset handling, and explicit meta delete emission
- update the docs to explain scheduled vs immediate delivery, the receiver-based test setup, current notification/filter behavior, and the leaner wp-env configuration

## Testing
- `npm run test:phpunit`