### PR TITLE
Add structured email webhooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ See [Astro Starlight Frontmatter Reference](https://starlight.astro.build/refere
 Add new docs with an "@" mention to the "AGENTS.md" including a quick explanation. Keep the docs always up to date.
 - @README.mdx - Quick start, basic usage, architecture overview
 - @docs/custom-webhooks.mdx - Creating webhooks, registry pattern, plugin integrations (WooCommerce, CF7, Gravity Forms)
+- @docs/email-webhooks.mdx - Capturing `wp_mail()` calls, structured email payloads, and optional send aborting
 - @docs/hooks-and-filters.mdx - All available hooks and filters with examples
 - @docs/configuration.mdx - Constants, configuration methods, precedence rules
 - @docs/notifications.mdx - Notification system, opt-in pattern, custom handlers

--- a/README.mdx
+++ b/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: WP Webhook Framework
-description: Entity-level webhooks for WordPress with scheduled and immediate delivery modes, retries, and failure monitoring.
+description: Entity-level webhooks for WordPress with scheduled and immediate delivery modes, retries, failure monitoring, and structured email webhooks.
 ---
 
 # WP Webhook Framework
@@ -8,7 +8,7 @@ description: Entity-level webhooks for WordPress with scheduled and immediate de
 [![Quality Check](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/quality-check.yml/badge.svg)](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/quality-check.yml)
 [![Integration Tests](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/JUVOJustin/wp-webhook-framework/actions/workflows/integration-tests.yml)
 
-Entity-level webhooks for WordPress using Action Scheduler with optional immediate delivery mode. Sends POSTs for create/update/delete of posts, terms, and users. Meta changes trigger the entity update. ACF updates include field context. Features intelligent failure monitoring with email notifications, automatic blocking, and comprehensive filtering options.
+Entity-level webhooks for WordPress using Action Scheduler with optional immediate delivery mode. Sends POSTs for create/update/delete of posts, terms, users, and outbound emails. Meta changes trigger the entity update. ACF updates include field context. Features intelligent failure monitoring with email notifications, automatic blocking, structured email payloads, and comprehensive filtering options.
 
 ## Features
 
@@ -16,6 +16,8 @@ Entity-level webhooks for WordPress using Action Scheduler with optional immedia
 - **Action Scheduler dispatch** - 5s delay for queued webhooks with deduplication
 - **Automatic deduplication** - Dispatcher-level on action+entity+id and meta-level per-request dedup for plugin hooks (ACF, Meta Box, etc.)
 - **Entity-aware delivery payloads** - Derives post_type, taxonomy, and roles at send time
+- **Structured email webhooks** - Captures `wp_mail()` calls with recipients, sender, subject, content, and headers
+- **Optional mail replacement** - Can short-circuit WordPress email delivery before PHPMailer or SMTP plugins run
 - **Send-time enrichment** - Adds REST URLs when available
 - **ACF integration** - Adds field key/name context to meta changes
 - **Registry pattern** - Extensible webhook system with custom configurations
@@ -87,6 +89,21 @@ add_action('wpwf_register_webhooks', function ($registry) {
 
 Immediate mode sends the first attempt in the current request. If it fails, retries are still queued asynchronously with exponential backoff.
 
+### Email Webhooks
+
+```php
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+add_action('wpwf_register_webhooks', function ($registry) {
+    $email = new Email_Webhook();
+    $email->webhook_url('https://api.example.com/emails')
+          ->abort_wp_mail();
+    $registry->register($email);
+});
+```
+
+The email webhook captures each `wp_mail()` call as a structured payload. With `abort_wp_mail()` enabled, WordPress reports the email as handled and skips PHPMailer plus SMTP plugin transport setup.
+
 ### Filter Payloads
 
 ```php
@@ -110,6 +127,7 @@ See [Hooks and Filters](./docs/hooks-and-filters.mdx) for all available hooks an
 - **Webhook** (abstract) - Base class for all webhooks
 - **Dispatcher** - Schedules and sends HTTP requests via Action Scheduler
 - **Entity Handlers** - Prepare payloads for posts, terms, users, and meta
+- **Email_Webhook** - Captures structured `wp_mail()` payloads before PHPMailer runs
 
 **Data Flow:**
 ```
@@ -134,6 +152,28 @@ Example post webhook payload:
   "entity": "post",
   "id": 123,
   "post_type": "post"
+}
+```
+
+Example email webhook payload:
+
+```json
+{
+  "action": "send",
+  "entity": "email",
+  "id": "2d53f2c4-9bc1-4f74-a4ef-c19e16a7a8d1",
+  "email": {
+    "to": [
+      {
+        "email": "jane@example.com",
+        "name": "Jane Recipient"
+      }
+    ],
+    "sender": "sender@example.com",
+    "sender_name": "Sender Example",
+    "subject": "Welcome aboard",
+    "content": "<p>Hello world</p>"
+  }
 }
 ```
 
@@ -182,6 +222,7 @@ composer run-script phpcbf    # Auto-fix code style
 
 - [Configuration](./docs/configuration.mdx) - Webhook configuration methods, registry setup, and options
 - [Custom Webhooks](./docs/custom-webhooks.mdx) - Creating custom webhooks, plugin integrations (WooCommerce, CF7, Gravity Forms)
+- [Email Webhooks](./docs/email-webhooks.mdx) - Capturing `wp_mail()` calls, structured payloads, and optional send aborting
 - [Hooks and Filters](./docs/hooks-and-filters.mdx) - All available hooks and filters with examples
 - [Failure Handling](./docs/failure-handling.mdx) - Failure monitoring, retry mechanism, and blocking behavior
 - [Notifications](./docs/notifications.mdx) - Notification system, opt-in pattern, and custom handlers

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -20,6 +20,7 @@ Configure individual webhooks using chainable methods.
 | `timeout(int)` | HTTP timeout in seconds (1-300) | 30 |
 | `headers(array)` | Custom HTTP headers | [] |
 | `notifications(array)` | Enable notification handlers | [] |
+| `abort_wp_mail(bool)` | Replace the original `wp_mail()` send (email webhook only) | `false` |
 
 ### Delivery Modes
 
@@ -81,6 +82,27 @@ $webhook->webhook_url( 'https://api.example.com' )
         ->notifications( array( 'blocked' ) );
 ```
 
+### Email Webhook Configuration
+
+The built-in `Email_Webhook` can either observe every `wp_mail()` call or replace
+the original email send entirely:
+
+```php
+use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
+    $email = new Email_Webhook();
+
+    $email->webhook_url( 'https://api.example.com/emails' )
+          ->abort_wp_mail();
+
+    $registry->register( $email );
+} );
+```
+
+`abort_wp_mail()` uses WordPress' `pre_wp_mail` short-circuit hook, so the webhook can stop delivery before PHPMailer and SMTP plugins run.
+
 ## Registry Configuration
 
 Register webhooks via the `wpwf_register_webhooks` action. No webhooks are
@@ -119,6 +141,8 @@ Use WordPress filters for dynamic configuration. See [Hooks and Filters](./hooks
 - `wpwf_url` - Dynamic URL routing
 - `wpwf_headers` - Dynamic headers
 - `wpwf_payload` - Payload modification
+- `wpwf_email_payload` - Email-only structured payload modification
+- `wpwf_email_abort_send` - Per-email `wp_mail()` short-circuit control
 - `wpwf_excluded_meta` - Meta key filtering
 
 ## Options-Based Configuration

--- a/docs/custom-webhooks.mdx
+++ b/docs/custom-webhooks.mdx
@@ -60,6 +60,8 @@ add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): v
 
 See [Configuration](./configuration.mdx) for detailed options.
 
+If you want built-in support for `wp_mail()` interception, use [Email Webhooks](./email-webhooks.mdx) instead of creating a custom implementation from scratch.
+
 ## Plugin Integration Examples
 
 ### WooCommerce Orders

--- a/docs/email-webhooks.mdx
+++ b/docs/email-webhooks.mdx
@@ -1,0 +1,101 @@
+---
+title: Email Webhooks
+description: Capture wp_mail() calls as structured webhook payloads and optionally replace WordPress email delivery.
+sidebar:
+  order: 6
+---
+
+Capture WordPress emails through `wp_mail()` and forward them as structured webhook payloads.
+
+## Registering the Built-in Email Webhook
+
+```php
+use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
+    $email = new Email_Webhook();
+    $email->webhook_url( 'https://api.example.com/emails' );
+
+    $registry->register( $email );
+} );
+```
+
+Once registered, the webhook listens to every `wp_mail()` call by default.
+
+## Structured Payload
+
+The request body keeps the standard framework envelope and adds an `email` object:
+
+```json
+{
+  "action": "send",
+  "entity": "email",
+  "id": "2d53f2c4-9bc1-4f74-a4ef-c19e16a7a8d1",
+  "email": {
+    "to": [
+      {
+        "email": "jane@example.com",
+        "name": "Jane Recipient"
+      }
+    ],
+    "cc": [],
+    "bcc": [],
+    "reply_to": [],
+    "sender": "sender@example.com",
+    "sender_name": "Sender Example",
+    "subject": "Welcome aboard",
+    "content": "<p>Hello world</p>",
+    "content_type": "text/html",
+    "charset": "UTF-8",
+    "headers": {
+      "x-custom-trace": "abc123"
+    },
+    "attachments": []
+  }
+}
+```
+
+## Aborting the Original Email Send
+
+Use `abort_wp_mail()` when the webhook should replace WordPress email delivery entirely:
+
+```php
+use juvo\WP_Webhook_Framework\Webhook_Registry;
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+add_action( 'wpwf_register_webhooks', function ( Webhook_Registry $registry ): void {
+    $email = new Email_Webhook();
+
+    $email->webhook_url( 'https://api.example.com/emails' )
+          ->abort_wp_mail();
+
+    $registry->register( $email );
+} );
+```
+
+This uses WordPress' `pre_wp_mail` filter, which runs before PHPMailer is initialized. Because of that, SMTP plugins that hook into `phpmailer_init` or replace the PHPMailer transport never receive the original email when abort mode is enabled.
+
+## Filtering Email Webhooks
+
+- Use `wpwf_payload` to filter the final webhook payload like any other entity (`$entity === 'email'`).
+- Use `wpwf_email_payload` to target only the structured `email` object before it is wrapped in the request body.
+- Use `wpwf_email_abort_send` to decide per-email whether the original `wp_mail()` call should be short-circuited.
+
+```php
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+add_filter( 'wpwf_email_abort_send', function ( bool $abort, array $email_data, Email_Webhook $webhook ): bool {
+    if ( 'Critical alert' !== $email_data['subject'] ) {
+        return $abort;
+    }
+
+    return true;
+}, 10, 3 );
+```
+
+## Compatibility Notes
+
+- The webhook only observes emails sent through `wp_mail()`.
+- Short-circuit mode returns `true` to WordPress, so callers still see the mail send as successful.
+- Because interception happens before PHPMailer setup, this is the safest place to avoid duplicate sending with SMTP plugins.

--- a/docs/hooks-and-filters.mdx
+++ b/docs/hooks-and-filters.mdx
@@ -86,7 +86,7 @@ Filter webhook payloads before scheduling. Payloads contain event-time fields on
 
 **Parameters:**
 - `$payload` (array<string,mixed>) - The webhook payload data
-- `$entity` (string) - The entity type (post, term, user, meta)
+- `$entity` (string) - The entity type (post, term, user, meta, email)
 - `$id` (int|string) - The entity ID
 
 **Returns:** array<string,mixed>|false
@@ -122,7 +122,7 @@ The framework already enriches `rest_url` at delivery time when possible. Use th
 **Parameters:**
 - `$body` (array<string,mixed>) - The full webhook body
 - `$action` (string) - The action type
-- `$entity` (string) - The entity type (post, term, user, meta)
+- `$entity` (string) - The entity type (post, term, user, meta, email)
 - `$id` (int|string) - The entity ID
 - `$payload` (array<string,mixed>) - The scheduled payload data
 - `$webhook` (`Webhook`) - The webhook instance
@@ -302,6 +302,50 @@ add_filter( 'wpwf_delivery_mode', function ( string $delivery_mode, string $webh
 }, 10, 2 );
 ```
 
+### `wpwf_email_payload`
+
+Filter the structured email payload before it is wrapped into the webhook request body. Return `false` to skip webhook emission for the current `wp_mail()` call.
+
+**Parameters:**
+- `$email_data` (array<string,mixed>|false) - The structured email payload
+- `$atts` (array<string,mixed>) - The filtered `wp_mail()` arguments
+- `$webhook` (`Email_Webhook`) - The email webhook instance
+
+**Returns:** array<string,mixed>|false
+
+```php
+add_filter( 'wpwf_email_payload', function ( array $email_data, array $atts ): array|false {
+    if ( 'Daily digest' !== $atts['subject'] ) {
+        return $email_data;
+    }
+
+    return false;
+}, 10, 3 );
+```
+
+### `wpwf_email_abort_send`
+
+Filter whether the email webhook should short-circuit the original `wp_mail()` call.
+
+**Parameters:**
+- `$abort` (bool) - Whether the original mail send should be skipped
+- `$email_data` (array<string,mixed>) - The structured email payload
+- `$webhook` (`Email_Webhook`) - The email webhook instance
+
+**Returns:** bool
+
+```php
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+add_filter( 'wpwf_email_abort_send', function ( bool $abort, array $email_data, Email_Webhook $webhook ): bool {
+    if ( 'Critical alert' !== $email_data['subject'] ) {
+        return $abort;
+    }
+
+    return true;
+}, 10, 3 );
+```
+
 ### `wpwf_retry_base_time`
 
 Filter the base time (seconds) for exponential backoff. Default: 60.
@@ -336,9 +380,31 @@ Example payload (post):
 ```json
 {
   "action": "create|update|delete",
-  "entity": "post|term|user|meta",
+  "entity": "post|term|user|meta|email",
   "id": 123,
   "post_type": "post"
+}
+```
+
+Example payload (email):
+
+```json
+{
+  "action": "send",
+  "entity": "email",
+  "id": "2d53f2c4-9bc1-4f74-a4ef-c19e16a7a8d1",
+  "email": {
+    "to": [
+      {
+        "email": "jane@example.com",
+        "name": "Jane Recipient"
+      }
+    ],
+    "sender": "sender@example.com",
+    "sender_name": "Sender Example",
+    "subject": "Welcome aboard",
+    "content": "<p>Hello world</p>"
+  }
 }
 ```
 
@@ -362,3 +428,5 @@ Filters are applied in this order:
 4. `wpwf_request_body` - Modify final request body before send
 5. `wpwf_headers` - Customize HTTP headers
 6. `wpwf_excluded_meta` - Filter meta keys (meta webhooks only)
+7. `wpwf_email_payload` - Adjust structured email payloads before emission
+8. `wpwf_email_abort_send` - Decide whether email webhooks replace `wp_mail()`

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -40,6 +40,7 @@ npm run wp-env:stop
 - `tests/phpunit/PostWebhookCrudTest.php`, `tests/phpunit/TermWebhookCrudTest.php`, and `tests/phpunit/UserWebhookCrudTest.php` provide separate CRUD examples per entity.
 - `tests/phpunit/MetaWebhookTest.php` covers meta emission modes, parent entity updates, and delivery payload enrichment.
 - `tests/phpunit/DeliveryModeTest.php` covers scheduled vs immediate dispatch behavior.
+- `tests/phpunit/EmailWebhookTest.php` covers structured `wp_mail()` payloads, email-specific filters, and optional mail aborting.
 - `tests/phpunit/WebhookFilterTest.php` covers runtime filters for delivery mode, URL routing, payload suppression, headers, and request body changes.
 - `tests/phpunit/WebhookFailureHandlingTest.php` covers retries, backoff scheduling metadata, and URL blocking behavior.
 - `tests/phpunit/NotificationAndFailureStateTest.php` covers blocked email notifications and expired-block recovery.

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -35,13 +35,14 @@ class Dispatcher {
 	 * @param array<string,mixed> $headers       The request headers.
 	 *
 	 * @throws WP_Exception If Action Scheduler is not active or URL/payload issues.
+	 * @return bool True when a new action was scheduled.
 	 */
-	public function schedule( string $action, string $entity, int|string $id, string $url = '', array $payload = array(), array $headers = array() ): void {
+	public function schedule( string $action, string $entity, int|string $id, string $url = '', array $payload = array(), array $headers = array() ): bool {
 		$this->ensure_action_scheduler_available();
 
 		$dispatch_data = $this->resolve_dispatch_data( $entity, $id, $url, $payload );
 		if ( null === $dispatch_data ) {
-			return;
+			return false;
 		}
 
 		$url     = $dispatch_data['url'];
@@ -66,7 +67,7 @@ class Dispatcher {
 		);
 
 		if ( ! empty( $query ) ) {
-			return;
+			return false;
 		}
 
 		as_schedule_single_action(
@@ -82,6 +83,8 @@ class Dispatcher {
 			),
 			$group
 		);
+
+		return true;
 	}
 
 	/**
@@ -98,11 +101,12 @@ class Dispatcher {
 	 * @param array<string,mixed> $headers       The request headers.
 	 *
 	 * @throws WP_Exception If URL/payload/webhook configuration is invalid.
+	 * @return bool True when the webhook request was attempted.
 	 */
-	public function dispatch_immediately( string $action, string $entity, int|string $id, string $url = '', array $payload = array(), array $headers = array() ): void {
+	public function dispatch_immediately( string $action, string $entity, int|string $id, string $url = '', array $payload = array(), array $headers = array() ): bool {
 		$dispatch_data = $this->resolve_dispatch_data( $entity, $id, $url, $payload );
 		if ( null === $dispatch_data ) {
-			return;
+			return false;
 		}
 
 		$webhook = $this->get_webhook_from_headers( $headers );
@@ -116,6 +120,8 @@ class Dispatcher {
 			$headers,
 			$webhook
 		);
+
+		return true;
 	}
 
 	/**

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -342,13 +342,14 @@ abstract class Webhook {
 	 * Payload and headers passed as parameters are merged with configured headers.
 	 *
 	 * @param string              $action      The action type (create, update, delete).
-	 * @param string              $entity_type The entity type (post, term, user, meta).
+	 * @param string              $entity_type The entity type (post, term, user, meta, email).
 	 * @param int|string          $entity_id   The entity ID.
 	 * @param array<string,mixed> $payload     Dynamic payload data for this emission.
 	 * @param array<string,mixed> $headers       Optional dynamic headers (merged with get_headers()).
 	 * @param Delivery_Mode|null  $delivery_mode Optional per-emission mode override.
+	 * @return bool True when the webhook was dispatched or queued.
 	 */
-	protected function emit( string $action, string $entity_type, int|string $entity_id, array $payload = array(), array $headers = array(), ?Delivery_Mode $delivery_mode = null ): void {
+	protected function emit( string $action, string $entity_type, int|string $entity_id, array $payload = array(), array $headers = array(), ?Delivery_Mode $delivery_mode = null ): bool {
 		$registry   = Webhook_Registry::instance();
 		$dispatcher = $registry->get_dispatcher();
 
@@ -360,13 +361,15 @@ abstract class Webhook {
 		try {
 			if ( Delivery_Mode::IMMEDIATE === $resolved_delivery_mode ) {
 				$dispatcher->dispatch_immediately( $action, $entity_type, $entity_id, $this->get_webhook_url(), $payload, $final_headers );
-				return;
+				return true;
 			}
 
 			$dispatcher->schedule( $action, $entity_type, $entity_id, $this->get_webhook_url(), $payload, $final_headers );
+			return true;
 		} catch ( \WP_Exception $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped -- Error handling context, no escaping needed.
 			trigger_error( sprintf( 'Failed to emit webhook "%s": %s', $this->name, $e->getMessage() ), E_USER_WARNING );
+			return false;
 		}
 	}
 }

--- a/src/Webhooks/Email_Webhook.php
+++ b/src/Webhooks/Email_Webhook.php
@@ -1,0 +1,471 @@
+<?php
+/**
+ * Email webhook implementation.
+ *
+ * @package juvo\WP_Webhook_Framework\Webhooks
+ */
+
+declare(strict_types=1);
+
+namespace juvo\WP_Webhook_Framework\Webhooks;
+
+use juvo\WP_Webhook_Framework\Webhook;
+
+/**
+ * Captures `wp_mail()` calls as structured webhook events.
+ *
+ * Hooks into `pre_wp_mail` so webhook delivery can optionally replace the
+ * original mail transport before PHPMailer or SMTP plugins send the message.
+ */
+class Email_Webhook extends Webhook {
+
+	/**
+	 * Controls whether the original `wp_mail()` call is short-circuited.
+	 *
+	 * @var bool
+	 */
+	private bool $abort_wp_mail = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name The webhook name.
+	 * @phpstan-param non-empty-string $name
+	 */
+	public function __construct( string $name = '' ) {
+		if ( '' === $name ) {
+			$name = 'email';
+		}
+
+		parent::__construct( $name );
+	}
+
+	/**
+	 * Configure whether webhook delivery replaces the actual email send.
+	 *
+	 * @param bool $abort Whether to short-circuit `wp_mail()` after emission.
+	 * @return static
+	 */
+	public function abort_wp_mail( bool $abort = true ): static {
+		$this->abort_wp_mail = $abort;
+		return $this;
+	}
+
+	/**
+	 * Register the mail interception hook.
+	 */
+	public function init(): void {
+		\add_filter( 'pre_wp_mail', array( $this, 'on_pre_wp_mail' ), 10, 2 );
+	}
+
+	/**
+	 * Emit a structured webhook payload for each `wp_mail()` call.
+	 *
+	 * Returning `true` short-circuits WordPress mail delivery, which prevents
+	 * PHPMailer and SMTP transport plugins from sending the original email.
+	 *
+	 * @param null|bool           $pre_wp_mail Short-circuit value from earlier filters.
+	 * @param array<string,mixed> $atts   Filtered `wp_mail()` arguments.
+	 * @return null|bool
+	 */
+	public function on_pre_wp_mail( null|bool $pre_wp_mail, array $atts ): null|bool {
+		if ( null !== $pre_wp_mail ) {
+			return $pre_wp_mail;
+		}
+
+		$email_data = $this->build_email_data( $atts );
+
+		$email_data = $this->filter_email_payload( $email_data, $atts );
+
+		if ( false === $email_data ) {
+			return null;
+		}
+
+		$did_emit = $this->emit(
+			'send',
+			'email',
+			\wp_generate_uuid4(),
+			array(
+				'email' => $email_data,
+			)
+		);
+
+		if ( ! $this->should_abort_wp_mail( $email_data ) || ! $did_emit ) {
+			return null;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolve whether this email should replace the original `wp_mail()` call.
+	 *
+	 * @param array<string,mixed> $email_data The structured email payload.
+	 * @return bool
+	 */
+	private function should_abort_wp_mail( array $email_data ): bool {
+		/**
+		 * Filter whether an email webhook should short-circuit `wp_mail()`.
+		 *
+		 * Returning `true` tells WordPress the email was handled successfully and
+		 * skips PHPMailer setup as well as SMTP plugin transports.
+		 *
+		 * @param bool          $abort      Whether to abort the original `wp_mail()` call.
+		 * @param array<string,mixed> $email_data Structured email payload.
+		 * @param Email_Webhook $webhook    The email webhook instance.
+		 */
+		return (bool) \apply_filters( 'wpwf_email_abort_send', $this->abort_wp_mail, $email_data, $this );
+	}
+
+	/**
+	 * Build the structured email payload that downstream systems can replay.
+	 *
+	 * @param array<string,mixed> $atts Filtered `wp_mail()` arguments.
+	 * @return array<string,mixed>
+	 */
+	private function build_email_data( array $atts ): array {
+		$to           = $this->parse_address_list( $atts['to'] ?? array() );
+		$header_lines = $this->normalize_header_lines( $atts['headers'] ?? array() );
+		$header_data  = $this->parse_headers( $header_lines );
+
+		$subject = $atts['subject'] ?? '';
+		$message = $atts['message'] ?? '';
+
+		return array(
+			'recipient'    => $to,
+			'to'           => $to,
+			'cc'           => $header_data['cc'],
+			'bcc'          => $header_data['bcc'],
+			'reply_to'     => $header_data['reply_to'],
+			'recipients'   => array(
+				'to'       => $this->parse_address_list( $atts['to'] ?? array() ),
+				'cc'       => $header_data['cc'],
+				'bcc'      => $header_data['bcc'],
+				'reply_to' => $header_data['reply_to'],
+			),
+			'sender'       => $header_data['from_email'],
+			'sender_name'  => $header_data['from_name'],
+			'from'         => array(
+				'email' => $header_data['from_email'],
+				'name'  => $header_data['from_name'],
+			),
+			'subject'      => is_scalar( $subject ) ? (string) $subject : '',
+			'content'      => is_scalar( $message ) ? (string) $message : '',
+			'content_type' => $header_data['content_type'],
+			'charset'      => $header_data['charset'],
+			'headers'      => $header_data['custom_headers'],
+			'header_lines' => $header_lines,
+			'attachments'  => $this->normalize_string_array( $atts['attachments'] ?? array() ),
+			'embeds'       => $this->normalize_string_array( $atts['embeds'] ?? array() ),
+		);
+	}
+
+	/**
+	 * Filter the structured email payload with runtime validation.
+	 *
+	 * @param array<string,mixed> $email_data Structured email payload.
+	 * @param array<string,mixed> $atts       Filtered `wp_mail()` arguments.
+	 * @return array<string,mixed>|false
+	 */
+	private function filter_email_payload( array $email_data, array $atts ): array|false {
+		/**
+		 * Filter the structured email webhook payload before emission.
+		 *
+		 * Return `false` to skip webhook delivery for the current email while
+		 * allowing WordPress to continue its normal mail workflow.
+		 */
+		return $this->validate_filtered_email_payload( \apply_filters( 'wpwf_email_payload', $email_data, $atts, $this ) );
+	}
+
+	/**
+	 * Validate the email payload returned by runtime filters.
+	 *
+	 * @param mixed $filtered_email_data Filter output from `wpwf_email_payload`.
+	 * @return array<string,mixed>|false
+	 */
+	private function validate_filtered_email_payload( mixed $filtered_email_data ): array|false {
+		if ( false === $filtered_email_data ) {
+			return false;
+		}
+
+		if ( ! is_array( $filtered_email_data ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error, WordPress.Security.EscapeOutput.OutputNotEscaped -- Error handling context, no escaping needed.
+			trigger_error( 'Failed to emit webhook "' . $this->get_name() . '": email webhook payload must be an array.', E_USER_WARNING );
+			return false;
+		}
+
+		return $filtered_email_data;
+	}
+
+	/**
+	 * Normalize raw header input into the line format used by core.
+	 *
+	 * @param mixed $headers Raw `wp_mail()` headers value.
+	 * @return array<int,string>
+	 */
+	private function normalize_header_lines( mixed $headers ): array {
+		if ( is_string( $headers ) ) {
+			$headers = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
+		}
+
+		if ( ! is_array( $headers ) ) {
+			return array();
+		}
+
+		$normalized = array();
+
+		foreach ( $headers as $header_line ) {
+			if ( ! is_scalar( $header_line ) ) {
+				continue;
+			}
+
+			$header_line = trim( (string) $header_line );
+			if ( '' === $header_line ) {
+				continue;
+			}
+
+			$normalized[] = $header_line;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Parse headers into the structured fields used by the webhook payload.
+	 *
+	 * Mirrors the relevant `wp_mail()` parsing rules so the webhook contains the
+	 * same sender and header context that WordPress would use for delivery.
+	 *
+	 * @param array<int,string> $header_lines Normalized header lines.
+	 * @return array{
+	 *     from_email: string,
+	 *     from_name: string,
+	 *     cc: array<int,array{email: string, name: string}>,
+	 *     bcc: array<int,array{email: string, name: string}>,
+	 *     reply_to: array<int,array{email: string, name: string}>,
+	 *     content_type: string,
+	 *     charset: string,
+	 *     custom_headers: array<string,string>
+	 * }
+	 */
+	private function parse_headers( array $header_lines ): array {
+		$from_email     = '';
+		$from_name      = '';
+		$content_type   = '';
+		$charset        = '';
+		$custom_headers = array();
+		$cc             = array();
+		$bcc            = array();
+		$reply_to       = array();
+
+		foreach ( $header_lines as $header_line ) {
+			if ( ! str_contains( $header_line, ':' ) ) {
+				continue;
+			}
+
+			list( $name, $content ) = explode( ':', $header_line, 2 );
+
+			$name    = trim( $name );
+			$content = trim( $content );
+
+			switch ( strtolower( $name ) ) {
+				case 'from':
+					$from       = $this->parse_single_address( $content );
+					$from_email = $from['email'];
+					$from_name  = $from['name'];
+					break;
+				case 'cc':
+					$cc = array_merge( $cc, $this->parse_address_list( $content ) );
+					break;
+				case 'bcc':
+					$bcc = array_merge( $bcc, $this->parse_address_list( $content ) );
+					break;
+				case 'reply-to':
+					$reply_to = array_merge( $reply_to, $this->parse_address_list( $content ) );
+					break;
+				case 'content-type':
+					list( $content_type, $charset ) = $this->parse_content_type_header( $content );
+					break;
+				default:
+					$custom_headers[ strtolower( $name ) ] = $content;
+			}
+		}
+
+		if ( '' === $from_name ) {
+			$from_name = 'WordPress';
+		}
+
+		if ( '' === $from_email ) {
+			$from_email = $this->get_default_from_email();
+		}
+
+		$from_email = (string) \apply_filters( 'wp_mail_from', $from_email );
+		$from_name  = (string) \apply_filters( 'wp_mail_from_name', $from_name );
+
+		if ( '' === $content_type ) {
+			$content_type = 'text/plain';
+		}
+
+		$content_type = (string) \apply_filters( 'wp_mail_content_type', $content_type );
+
+		if ( '' === $charset ) {
+			$charset = \get_bloginfo( 'charset' );
+		}
+
+		$charset = (string) \apply_filters( 'wp_mail_charset', $charset );
+
+		return array(
+			'from_email'     => $from_email,
+			'from_name'      => $from_name,
+			'cc'             => $cc,
+			'bcc'            => $bcc,
+			'reply_to'       => $reply_to,
+			'content_type'   => $content_type,
+			'charset'        => $charset,
+			'custom_headers' => $custom_headers,
+		);
+	}
+
+	/**
+	 * Parse the Content-Type header into MIME type and charset.
+	 *
+	 * @param string $content The raw Content-Type header value.
+	 * @return array{0: string, 1: string}
+	 */
+	private function parse_content_type_header( string $content ): array {
+		$content_type = trim( $content );
+		$charset      = '';
+
+		if ( ! str_contains( $content, ';' ) ) {
+			return array( $content_type, $charset );
+		}
+
+		$parts        = array_map( 'trim', explode( ';', $content ) );
+		$content_type = array_shift( $parts ) ?: '';
+
+		foreach ( $parts as $part ) {
+			if ( ! str_contains( strtolower( $part ), 'charset=' ) ) {
+				continue;
+			}
+
+			$charset = trim( str_replace( array( 'charset=', 'CHARSET=', '"' ), '', $part ) );
+			break;
+		}
+
+		return array( $content_type, $charset );
+	}
+
+	/**
+	 * Parse one or more address values into a structured list.
+	 *
+	 * @param mixed $addresses Raw `wp_mail()` recipient value.
+	 * @return array<int,array{email: string, name: string}>
+	 */
+	private function parse_address_list( mixed $addresses ): array {
+		$values = $this->normalize_string_array( $addresses, true );
+		$parsed = array();
+
+		foreach ( $values as $address ) {
+			$parsed_address = $this->parse_single_address( $address );
+			if ( '' === $parsed_address['email'] ) {
+				continue;
+			}
+
+			$parsed[] = $parsed_address;
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Parse a single mailbox string into email and display name.
+	 *
+	 * @param string $address Raw mailbox string.
+	 * @return array{email: string, name: string}
+	 */
+	private function parse_single_address( string $address ): array {
+		$address = trim( $address );
+
+		if ( '' === $address ) {
+			return array(
+				'email' => '',
+				'name'  => '',
+			);
+		}
+
+		if ( preg_match( '/^(.*)<([^>]+)>$/', $address, $matches ) ) {
+			return array(
+				'email' => trim( $matches[2] ),
+				'name'  => trim( trim( $matches[1] ), '" ' ),
+			);
+		}
+
+		return array(
+			'email' => $address,
+			'name'  => '',
+		);
+	}
+
+	/**
+	 * Normalize mixed scalar-or-array input into string values.
+	 *
+	 * `wp_mail()` accepts strings, newline-delimited strings, arrays, and
+	 * comma-separated address lists. This helper keeps webhook payloads stable.
+	 *
+	 * @param mixed $values          Raw value from `wp_mail()` arguments.
+	 * @param bool  $split_on_commas Whether comma-separated values should be split.
+	 * @return array<int,string>
+	 */
+	private function normalize_string_array( mixed $values, bool $split_on_commas = false ): array {
+		if ( is_string( $values ) ) {
+			$values = str_replace( "\r\n", "\n", $values );
+
+			if ( $split_on_commas ) {
+				$values = str_getcsv( $values, ',' );
+			} else {
+				$values = explode( "\n", $values );
+			}
+		}
+
+		if ( ! is_array( $values ) ) {
+			return array();
+		}
+
+		$normalized = array();
+
+		foreach ( $values as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $value );
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$normalized[] = $value;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Reproduce WordPress' default sender email fallback.
+	 *
+	 * @return string
+	 */
+	private function get_default_from_email(): string {
+		$sitename   = \wp_parse_url( \network_home_url(), PHP_URL_HOST );
+		$from_email = 'wordpress@';
+
+		if ( ! is_string( $sitename ) || '' === $sitename ) {
+			return $from_email;
+		}
+
+		if ( str_starts_with( $sitename, 'www.' ) ) {
+			$sitename = substr( $sitename, 4 );
+		}
+
+		return $from_email . $sitename;
+	}
+}

--- a/src/Webhooks/Email_Webhook.php
+++ b/src/Webhooks/Email_Webhook.php
@@ -30,7 +30,6 @@ class Email_Webhook extends Webhook {
 	 * Constructor.
 	 *
 	 * @param string $name The webhook name.
-	 * @phpstan-param non-empty-string $name
 	 */
 	public function __construct( string $name = '' ) {
 		if ( '' === $name ) {

--- a/tests/phpunit/EmailWebhookTest.php
+++ b/tests/phpunit/EmailWebhookTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Covers structured email webhook delivery.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhooks\Email_Webhook;
+
+/**
+ * Verifies `wp_mail()` interception, structured payloads, and abort behavior.
+ */
+final class EmailWebhookTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Ensures email webhooks emit the expected structured payload.
+	 */
+	public function test_email_webhook_emits_structured_payload(): void {
+		$webhook = $this->register_email_webhook( 'structured', true, Delivery_Mode::IMMEDIATE );
+
+		try {
+			$result = \wp_mail(
+				array(
+					'Jane Recipient <jane@example.com>',
+					'john@example.com',
+				),
+				'Welcome aboard',
+				'<p>Hello world</p>',
+				array(
+					'From: Sender Example <sender@example.com>',
+					'Cc: Carbon Copy <cc@example.com>',
+					'Bcc: Blind Copy <bcc@example.com>',
+					'Reply-To: Reply Person <reply@example.com>',
+					'Content-Type: text/html; charset=UTF-8',
+					'X-Custom-Trace: abc123',
+				),
+				array(
+					'/tmp/example.pdf',
+				)
+			);
+
+			$this->assertTrue( $result );
+
+			$request = $this->get_captured_request_by_webhook_name( $webhook->get_name() );
+			$email   = $request['body']['email'];
+
+			$this->assertSame( 'send', $request['body']['action'] );
+			$this->assertSame( 'email', $request['body']['entity'] );
+			$this->assertSame( 'Welcome aboard', $email['subject'] );
+			$this->assertSame( '<p>Hello world</p>', $email['content'] );
+			$this->assertSame( 'sender@example.com', $email['sender'] );
+			$this->assertSame( 'Sender Example', $email['sender_name'] );
+			$this->assertSame( 'text/html', $email['content_type'] );
+			$this->assertSame( 'UTF-8', $email['charset'] );
+			$this->assertSame( 'abc123', $email['headers']['x-custom-trace'] );
+			$this->assertSame( '/tmp/example.pdf', $email['attachments'][0] );
+			$this->assertSame( 'jane@example.com', $email['to'][0]['email'] );
+			$this->assertSame( 'Jane Recipient', $email['to'][0]['name'] );
+			$this->assertSame( 'john@example.com', $email['to'][1]['email'] );
+			$this->assertSame( 'cc@example.com', $email['cc'][0]['email'] );
+			$this->assertSame( 'bcc@example.com', $email['bcc'][0]['email'] );
+			$this->assertSame( 'reply@example.com', $email['reply_to'][0]['email'] );
+		} finally {
+			$this->unregister_email_webhook( $webhook );
+		}
+	}
+
+	/**
+	 * Ensures abort mode short-circuits before PHPMailer initialization.
+	 */
+	public function test_email_webhook_abort_mode_prevents_phpmailer_send_flow(): void {
+		$webhook          = $this->register_email_webhook( 'abort', true );
+		$phpmailer_called = false;
+
+		$phpmailer_init = static function () use ( &$phpmailer_called ): void {
+			$phpmailer_called = true;
+		};
+
+		\add_action( 'phpmailer_init', $phpmailer_init, 10, 1 );
+
+		try {
+			$result = \wp_mail( 'abort@example.com', 'Abort test', 'Webhook only' );
+
+			$this->assertTrue( $result );
+			$this->assertFalse( $phpmailer_called );
+			$this->assertCount( 1, $this->get_captured_requests() );
+		} finally {
+			\remove_action( 'phpmailer_init', $phpmailer_init, 10 );
+			$this->unregister_email_webhook( $webhook );
+		}
+	}
+
+	/**
+	 * Ensures non-abort mode keeps the `wp_mail()` pipeline open for later hooks.
+	 */
+	public function test_email_webhook_can_emit_without_aborting_wp_mail(): void {
+		$webhook            = $this->register_email_webhook( 'continue', false );
+		$downstream_reached = false;
+
+		$downstream_pre_wp_mail = static function ( $return, array $atts ) use ( &$downstream_reached ) {
+			if ( null !== $return || 'Continue mail' !== $atts['subject'] ) {
+				return $return;
+			}
+
+			$downstream_reached = true;
+			return true;
+		};
+
+		\add_filter( 'pre_wp_mail', $downstream_pre_wp_mail, 20, 2 );
+
+		try {
+			$result = \wp_mail( 'continue@example.com', 'Continue mail', 'Webhook and mail flow' );
+
+			$this->assertTrue( $result );
+			$this->assertTrue( $downstream_reached );
+			$this->assertCount( 1, $this->get_captured_requests() );
+		} finally {
+			\remove_filter( 'pre_wp_mail', $downstream_pre_wp_mail, 20 );
+			$this->unregister_email_webhook( $webhook );
+		}
+	}
+
+	/**
+	 * Ensures the email-specific payload filter can skip webhook delivery.
+	 */
+	public function test_email_payload_filter_can_skip_delivery(): void {
+		$webhook = $this->register_email_webhook( 'filtered', true );
+
+		$email_payload_filter = static function ( array $email_data, array $atts ) {
+			if ( 'Skip me' !== $atts['subject'] ) {
+				return $email_data;
+			}
+
+			return false;
+		};
+
+		$fallback_pre_wp_mail = static function ( $return, array $atts ) {
+			if ( null !== $return || 'Skip me' !== $atts['subject'] ) {
+				return $return;
+			}
+
+			return true;
+		};
+
+		\add_filter( 'wpwf_email_payload', $email_payload_filter, 10, 3 );
+		\add_filter( 'pre_wp_mail', $fallback_pre_wp_mail, 20, 2 );
+
+		try {
+			$result = \wp_mail( 'skip@example.com', 'Skip me', 'No webhook should be sent' );
+
+			$this->assertTrue( $result );
+			$this->assertCount( 0, $this->get_captured_requests() );
+		} finally {
+			\remove_filter( 'wpwf_email_payload', $email_payload_filter, 10 );
+			\remove_filter( 'pre_wp_mail', $fallback_pre_wp_mail, 20 );
+			$this->unregister_email_webhook( $webhook );
+		}
+	}
+
+	/**
+	 * Ensures the abort filter can force mail replacement at runtime.
+	 */
+	public function test_email_abort_filter_can_force_short_circuit(): void {
+		$webhook = $this->register_email_webhook( 'abort-filter', false );
+
+		$abort_filter = static function ( bool $abort, array $email_data ): bool {
+			if ( 'Force abort' !== $email_data['subject'] ) {
+				return $abort;
+			}
+
+			return true;
+		};
+
+		try {
+			\add_filter( 'wpwf_email_abort_send', $abort_filter, 10, 3 );
+
+			$result = \wp_mail( 'forced@example.com', 'Force abort', 'Abort via filter' );
+
+			$this->assertTrue( $result );
+			$this->assertCount( 1, $this->get_captured_requests() );
+		} finally {
+			\remove_filter( 'wpwf_email_abort_send', $abort_filter, 10 );
+			$this->unregister_email_webhook( $webhook );
+		}
+	}
+
+	/**
+	 * Register a temporary email webhook for the current test.
+	 *
+	 * @param string        $suffix        Readable name suffix.
+	 * @param bool          $abort_wp_mail Whether the original mail send should be aborted.
+	 * @param Delivery_Mode $delivery_mode Delivery mode under test.
+	 * @return Email_Webhook
+	 */
+	private function register_email_webhook( string $suffix, bool $abort_wp_mail, Delivery_Mode $delivery_mode = Delivery_Mode::IMMEDIATE ): Email_Webhook {
+		$name    = 'email_' . $suffix . '_' . str_replace( '.', '', uniqid( '', true ) );
+		$webhook = new Email_Webhook( $name );
+
+		$webhook->webhook_url( $this->get_receiver_webhook_url( 'email-' . $suffix ) );
+		$webhook->abort_wp_mail( $abort_wp_mail );
+		$webhook->delivery_mode( $delivery_mode );
+
+		Service_Provider::get_registry()->register( $webhook );
+
+		return $webhook;
+	}
+
+	/**
+	 * Remove the temporary email webhook hooks after the test completes.
+	 *
+	 * @param Email_Webhook $webhook The webhook instance to clean up.
+	 */
+	private function unregister_email_webhook( Email_Webhook $webhook ): void {
+		\remove_filter( 'pre_wp_mail', array( $webhook, 'on_pre_wp_mail' ), 10 );
+		Service_Provider::get_registry()->unregister( $webhook->get_name() );
+	}
+}


### PR DESCRIPTION
## Summary
- add a built-in `Email_Webhook` that captures every `wp_mail()` call as a structured `email` payload with recipients, sender data, content, headers, attachments, and embeds
- add optional `abort_wp_mail()` behavior plus email-specific filters so webhook delivery can replace WordPress mail transport before PHPMailer and SMTP plugins run
- add application tests and docs covering structured payloads, filtering, and mail short-circuit behavior

## Testing
- `npm run test:phpunit`
- `npx wp-env run cli --env-cwd=wp-content/wpwf-framework composer run-script phpstan`
- `npx wp-env run cli --env-cwd=wp-content/wpwf-framework composer run-script phpcs`
- `npx wp-env run cli --env-cwd=wp-content/wpwf-framework vendor/bin/phpunit -c phpunit.xml.dist tests/phpunit/EmailWebhookTest.php`