### PR TITLE
Cover dispatcher exception paths and declare the WordPress 6.7 requirement

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,8 +8,24 @@ on:
 
 jobs:
   application-tests:
-    name: wp-env Application Tests
+    name: wp-env Application Tests (WP ${{ matrix.wordpress.name }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        wordpress:
+          # Minimum supported release. WP_Exception landed in core in 6.7.0, and
+          # the dispatcher throws it on every failure path, so this job proves the
+          # documented floor still boots.
+          - name: '6.7 (minimum)'
+            core: 'WordPress/WordPress#6.7'
+          # Latest release, resolved by wp-env when core is unset.
+          - name: 'latest'
+            core: ''
+
+    env:
+      WP_ENV_CORE: ${{ matrix.wordpress.core }}
 
     steps:
       - name: Checkout code

--- a/README.mdx
+++ b/README.mdx
@@ -31,7 +31,18 @@ Entity-level webhooks for WordPress using Action Scheduler with optional immedia
 composer require citation-media/wp-webhook-framework
 ```
 
-Requires PHP 8.1+.
+### Requirements
+
+| Requirement | Version |
+| --- | --- |
+| WordPress | 6.7 or newer |
+| PHP | 8.1 or newer |
+| Action Scheduler | 3.7 or newer (declared as a Composer dependency) |
+
+WordPress 6.7 is a hard requirement: the dispatcher signals every delivery and
+configuration failure by throwing [`WP_Exception`](https://developer.wordpress.org/reference/classes/wp_exception/),
+which was added to core in 6.7.0. On older releases those throw sites raise an
+uncatchable `Error: Class "WP_Exception" not found` instead.
 
 Ensure Action Scheduler is active (dependency is declared).
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -205,7 +205,7 @@ class Dispatcher {
 		$webhook  = $registry->get( $name );
 
 		if ( null === $webhook ) {
-			throw new WP_Exception( 'Webhook not found in registry.' );
+			throw new WP_Exception( 'webhook_not_found' );
 		}
 
 		return $webhook;

--- a/src/Service_Provider.php
+++ b/src/Service_Provider.php
@@ -20,6 +20,15 @@ use juvo\WP_Webhook_Framework\Notifications\Notification_Registry;
 class Service_Provider {
 
 	/**
+	 * Minimum WordPress version supported by the framework.
+	 *
+	 * The dispatcher signals every failure by throwing `WP_Exception`, which was
+	 * added to WordPress core in 6.7.0. On older releases those throw sites raise
+	 * an uncatchable "class not found" fatal, so the framework refuses to boot.
+	 */
+	public const MIN_WP_VERSION = '6.7';
+
+	/**
 	 * Singleton instance.
 	 *
 	 * @var Service_Provider|null
@@ -79,12 +88,48 @@ class Service_Provider {
 	}
 
 	/**
+	 * Check whether the current WordPress version supports the framework.
+	 *
+	 * @return bool True when WordPress is new enough to boot the framework.
+	 */
+	public static function is_supported_wp_version(): bool {
+		return version_compare( (string) get_bloginfo( 'version' ), self::MIN_WP_VERSION, '>=' );
+	}
+
+	/**
+	 * Print an admin notice explaining why the framework did not boot.
+	 */
+	public static function render_unsupported_wp_version_notice(): void {
+		printf(
+			'<div class="notice notice-error"><p>%s</p></div>',
+			esc_html(
+				sprintf(
+					/* translators: 1: required WordPress version, 2: current WordPress version */
+					__( 'WP Webhook Framework requires WordPress %1$s or newer and has been disabled. This site runs WordPress %2$s.', 'wp-webhook-framework' ),
+					self::MIN_WP_VERSION,
+					(string) get_bloginfo( 'version' )
+				)
+			)
+		);
+	}
+
+	/**
 	 * Registers all actions/filters. Safe to call multiple times.
+	 *
+	 * Bails out without registering anything when the WordPress version is older
+	 * than {@see self::MIN_WP_VERSION}, surfacing an admin notice instead of
+	 * letting the dispatcher fatal on a missing `WP_Exception` class.
 	 */
 	public static function register(): void {
 
 		// Guard against duplicate registration
 		if ( self::$registered ) {
+			return;
+		}
+
+		if ( ! self::is_supported_wp_version() ) {
+			add_action( 'admin_notices', array( self::class, 'render_unsupported_wp_version_notice' ) );
+			self::$registered = true;
 			return;
 		}
 

--- a/tests/phpunit/DispatcherExceptionTest.php
+++ b/tests/phpunit/DispatcherExceptionTest.php
@@ -1,0 +1,370 @@
+<?php
+/**
+ * Covers every WP_Exception throw site in the dispatcher.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Delivery_Mode;
+use juvo\WP_Webhook_Framework\Dispatcher;
+use juvo\WP_Webhook_Framework\Failure;
+use juvo\WP_Webhook_Framework\Service_Provider;
+use juvo\WP_Webhook_Framework\Webhook;
+
+/**
+ * Verifies that dispatcher failure paths surface as catchable WP_Exception instances.
+ *
+ * Action Scheduler only records an action as failed when the callback throws, so the
+ * exception contract is load-bearing for the queue. These tests pin both the exception
+ * type and the message identifier used at each throw site.
+ */
+final class DispatcherExceptionTest extends WPWF_Webhook_Test_Case {
+
+	/**
+	 * Dispatcher under test.
+	 *
+	 * @var Dispatcher
+	 */
+	private Dispatcher $dispatcher;
+
+	/**
+	 * Registered fixture webhook.
+	 *
+	 * @var Exception_Test_Webhook
+	 */
+	private Exception_Test_Webhook $webhook;
+
+	/**
+	 * Register a uniquely named fixture webhook for each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->dispatcher = Service_Provider::get_dispatcher();
+		$this->webhook    = $this->register_exception_webhook( 'default', $this->get_receiver_webhook_url( 'exception-default' ) );
+	}
+
+	/**
+	 * Guards the WordPress 6.7 baseline required by every throw site.
+	 *
+	 * WP_Exception ships with WordPress core as of 6.7.0. On older releases every
+	 * `throw new WP_Exception(...)` in the dispatcher becomes a fatal "class not found"
+	 * error that `Webhook::emit()` cannot catch.
+	 */
+	public function test_core_wp_exception_class_is_available(): void {
+		$this->assertTrue(
+			class_exists( '\WP_Exception' ),
+			'WP_Exception is missing. The framework requires WordPress 6.7 or newer.'
+		);
+		$this->assertTrue( is_subclass_of( '\WP_Exception', '\Exception' ) );
+	}
+
+	/**
+	 * Ensures an unset URL aborts scheduling instead of queueing an undeliverable action.
+	 */
+	public function test_schedule_throws_when_webhook_url_is_not_set(): void {
+		$this->expectException( \WP_Exception::class );
+		$this->expectExceptionMessage( 'webhook_url_not_set' );
+
+		$this->dispatcher->schedule( 'trigger', 'exception_test', 'no-url', '', array( 'reference' => 'no-url' ) );
+	}
+
+	/**
+	 * Ensures the same guard applies to the immediate delivery path.
+	 */
+	public function test_dispatch_immediately_throws_when_webhook_url_is_not_set(): void {
+		$this->expectException( \WP_Exception::class );
+		$this->expectExceptionMessage( 'webhook_url_not_set' );
+
+		$this->dispatcher->dispatch_immediately( 'trigger', 'exception_test', 'no-url-immediate', '', array( 'reference' => 'no-url-immediate' ) );
+	}
+
+	/**
+	 * Ensures a blocked destination is rejected before an action is queued.
+	 */
+	public function test_schedule_throws_when_url_is_blocked(): void {
+		$url = $this->get_receiver_webhook_url( 'exception-blocked-schedule' );
+		$this->block_url( $url );
+
+		try {
+			$this->dispatcher->schedule( 'trigger', 'exception_test', 'blocked', $url, array( 'reference' => 'blocked' ) );
+			$this->fail( 'Expected a WP_Exception for a blocked webhook URL.' );
+		} catch ( \WP_Exception $exception ) {
+			$this->assertSame( 'webhook_url_blocked', $exception->getMessage() );
+		}
+
+		$this->assertCount( 0, $this->get_scheduled_webhook_actions() );
+	}
+
+	/**
+	 * Ensures a payload filter returning a non-array value is rejected.
+	 */
+	public function test_schedule_throws_when_payload_filter_returns_non_array(): void {
+		$filter = static fn(): string => 'not-an-array';
+		add_filter( 'wpwf_payload', $filter, 99 );
+
+		try {
+			$this->dispatcher->schedule(
+				'trigger',
+				'exception_test',
+				'invalid-payload',
+				$this->get_receiver_webhook_url( 'exception-invalid-payload' ),
+				array( 'reference' => 'invalid-payload' )
+			);
+			$this->fail( 'Expected a WP_Exception for a non-array payload.' );
+		} catch ( \WP_Exception $exception ) {
+			$this->assertSame( 'webhook_payload_invalid', $exception->getMessage() );
+		} finally {
+			remove_filter( 'wpwf_payload', $filter, 99 );
+		}
+
+		$this->assertCount( 0, $this->get_scheduled_webhook_actions() );
+	}
+
+	/**
+	 * Ensures a filter that empties a previously populated payload is treated as an error.
+	 */
+	public function test_schedule_throws_when_payload_filter_empties_a_populated_payload(): void {
+		$filter = static fn(): array => array();
+		add_filter( 'wpwf_payload', $filter, 99 );
+
+		try {
+			$this->dispatcher->schedule(
+				'trigger',
+				'exception_test',
+				'empty-payload',
+				$this->get_receiver_webhook_url( 'exception-empty-payload' ),
+				array( 'reference' => 'empty-payload' )
+			);
+			$this->fail( 'Expected a WP_Exception for an emptied payload.' );
+		} catch ( \WP_Exception $exception ) {
+			$this->assertSame( 'webhook_payload_empty', $exception->getMessage() );
+		} finally {
+			remove_filter( 'wpwf_payload', $filter, 99 );
+		}
+
+		$this->assertCount( 0, $this->get_scheduled_webhook_actions() );
+	}
+
+	/**
+	 * Ensures an opt-out payload filter cancels dispatch without raising an exception.
+	 */
+	public function test_schedule_skips_silently_when_payload_filter_opts_out(): void {
+		$filter = static fn(): bool => false;
+		add_filter( 'wpwf_payload', $filter, 99 );
+
+		try {
+			$this->dispatcher->schedule(
+				'trigger',
+				'exception_test',
+				'opt-out',
+				$this->get_receiver_webhook_url( 'exception-opt-out' ),
+				array( 'reference' => 'opt-out' )
+			);
+		} finally {
+			remove_filter( 'wpwf_payload', $filter, 99 );
+		}
+
+		$this->assertCount( 0, $this->get_scheduled_webhook_actions() );
+	}
+
+	/**
+	 * Ensures a queued action for an unregistered webhook fails loudly.
+	 *
+	 * This happens when a plugin that owns a webhook is deactivated while its
+	 * actions are still pending in the queue.
+	 */
+	public function test_process_scheduled_webhook_throws_when_webhook_is_not_registered(): void {
+		$this->expectException( \WP_Exception::class );
+		$this->expectExceptionMessage( 'webhook_not_found' );
+
+		$this->dispatcher->process_scheduled_webhook(
+			$this->get_receiver_webhook_url( 'exception-unregistered' ),
+			'trigger',
+			'exception_test',
+			'unregistered',
+			array( 'reference' => 'unregistered' ),
+			array( 'wpwf-webhook-name' => 'wpwf_missing_webhook_name' )
+		);
+	}
+
+	/**
+	 * Ensures a queued action whose URL became blocked after scheduling fails loudly.
+	 */
+	public function test_process_scheduled_webhook_throws_when_url_is_blocked(): void {
+		$url = $this->get_receiver_webhook_url( 'exception-blocked-delivery' );
+		$this->block_url( $url );
+
+		$this->expectException( \WP_Exception::class );
+		$this->expectExceptionMessage( 'webhook_url_blocked' );
+
+		$this->dispatcher->process_scheduled_webhook(
+			$url,
+			'trigger',
+			'exception_test',
+			'blocked-delivery',
+			array( 'reference' => 'blocked-delivery' ),
+			$this->webhook->get_headers()
+		);
+	}
+
+	/**
+	 * Ensures a non-200 response throws so Action Scheduler records the action as failed.
+	 */
+	public function test_delivery_failure_throws_when_blocking_is_disabled(): void {
+		$url     = $this->get_receiver_webhook_url( 'exception-fail-unblocked', 'fail' );
+		$webhook = $this->register_exception_webhook( 'unblocked', $url );
+		$webhook->max_consecutive_failures( 0 );
+
+		try {
+			$this->dispatcher->process_scheduled_webhook(
+				$url,
+				'trigger',
+				'exception_test',
+				'fail-unblocked',
+				array( 'reference' => 'fail-unblocked' ),
+				$webhook->get_headers()
+			);
+			$this->fail( 'Expected a WP_Exception for a failed webhook delivery.' );
+		} catch ( \WP_Exception $exception ) {
+			$this->assertSame( 'webhook_delivery_failed', $exception->getMessage() );
+		}
+
+		$this->assertCount( 1, $this->get_captured_requests() );
+
+		// Blocking disabled means no failure state is accumulated.
+		$state = Failure::from_transient( $url );
+		$this->assertSame( 0, $state->get_count() );
+		$this->assertFalse( $state->is_blocked() );
+	}
+
+	/**
+	 * Ensures the throw still happens on the branch that tracks and blocks failures.
+	 */
+	public function test_delivery_failure_throws_and_blocks_url_at_threshold(): void {
+		$url     = $this->get_receiver_webhook_url( 'exception-fail-blocking', 'fail' );
+		$webhook = $this->register_exception_webhook( 'blocking', $url );
+		$webhook->max_consecutive_failures( 1 );
+
+		try {
+			$this->dispatcher->process_scheduled_webhook(
+				$url,
+				'trigger',
+				'exception_test',
+				'fail-blocking',
+				array( 'reference' => 'fail-blocking' ),
+				$webhook->get_headers()
+			);
+			$this->fail( 'Expected a WP_Exception for a failed webhook delivery.' );
+		} catch ( \WP_Exception $exception ) {
+			$this->assertSame( 'webhook_delivery_failed', $exception->getMessage() );
+		}
+
+		$state = Failure::from_transient( $url );
+		$this->assertSame( 1, $state->get_count() );
+		$this->assertTrue( $state->is_blocked() );
+	}
+
+	/**
+	 * Ensures `Webhook::emit()` converts dispatcher exceptions into a warning.
+	 *
+	 * Callers using the `Webhook` façade must never see an uncaught exception.
+	 */
+	public function test_emit_converts_dispatcher_exception_into_warning(): void {
+		$url     = $this->get_receiver_webhook_url( 'exception-emit-blocked' );
+		$webhook = $this->register_exception_webhook( 'emit', $url );
+		$webhook->delivery_mode( Delivery_Mode::IMMEDIATE );
+		$this->block_url( $url );
+
+		$messages = array();
+		set_error_handler(
+			static function ( int $error_level, string $message ) use ( &$messages ): bool {
+				if ( E_USER_WARNING !== $error_level ) {
+					return false;
+				}
+
+				$messages[] = $message;
+				return true;
+			}
+		);
+
+		try {
+			$webhook->trigger_event( 'emit-blocked' );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertCount( 1, $messages );
+		$this->assertStringContainsString( 'Failed to emit webhook', $messages[0] );
+		$this->assertStringContainsString( 'webhook_url_blocked', $messages[0] );
+	}
+
+	/**
+	 * Persist a blocked failure state for a URL.
+	 *
+	 * @param string $url The webhook URL to block.
+	 */
+	private function block_url( string $url ): void {
+		Failure::create_blocked()->save( $url );
+	}
+
+	/**
+	 * Register a uniquely named fixture webhook.
+	 *
+	 * @param string $suffix Unique test suffix.
+	 * @param string $url    Destination URL.
+	 * @return Exception_Test_Webhook
+	 */
+	private function register_exception_webhook( string $suffix, string $url ): Exception_Test_Webhook {
+		$name = 'exception_test_' . $suffix . '_' . str_replace( '.', '', uniqid( '', true ) );
+
+		$webhook = new Exception_Test_Webhook( $name, $url );
+		$webhook->max_retries( 0 );
+
+		Service_Provider::get_registry()->register( $webhook );
+
+		return $webhook;
+	}
+}
+
+/**
+ * Minimal fixture webhook used to exercise dispatcher exception paths.
+ */
+final class Exception_Test_Webhook extends Webhook {
+
+	/**
+	 * Configure the fixture endpoint.
+	 *
+	 * @param string $name Unique webhook name.
+	 * @param string $url  Delivery URL.
+	 */
+	public function __construct( string $name, string $url ) {
+		parent::__construct( $name );
+
+		$this->webhook_url( $url );
+	}
+
+	/**
+	 * No WordPress hooks are needed for this fixture webhook.
+	 */
+	public function init(): void {
+	}
+
+	/**
+	 * Emit a deterministic payload through the public façade.
+	 *
+	 * @param string $reference Stable ID used by assertions.
+	 */
+	public function trigger_event( string $reference ): void {
+		$this->emit(
+			'trigger',
+			'exception_test',
+			$reference,
+			array(
+				'reference' => $reference,
+			)
+		);
+	}
+}

--- a/tests/phpunit/RequirementsTest.php
+++ b/tests/phpunit/RequirementsTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Covers the minimum WordPress version requirement.
+ *
+ * @package juvo\WP_Webhook_Framework\Tests
+ */
+
+declare(strict_types=1);
+
+use juvo\WP_Webhook_Framework\Service_Provider;
+
+/**
+ * Verifies the framework refuses to boot below its documented WordPress floor.
+ */
+final class RequirementsTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensures the documented floor matches the version that introduced WP_Exception.
+	 */
+	public function test_minimum_wp_version_matches_wp_exception_availability(): void {
+		$this->assertSame( '6.7', Service_Provider::MIN_WP_VERSION );
+	}
+
+	/**
+	 * Ensures the current test environment satisfies the requirement.
+	 */
+	public function test_current_environment_is_supported(): void {
+		$this->assertTrue(
+			Service_Provider::is_supported_wp_version(),
+			sprintf( 'Test environment runs WordPress %s.', (string) get_bloginfo( 'version' ) )
+		);
+		$this->assertTrue( class_exists( '\WP_Exception' ) );
+	}
+
+	/**
+	 * Ensures releases below the floor are rejected.
+	 *
+	 * @dataProvider unsupported_versions
+	 *
+	 * @param string $version A WordPress version older than the floor.
+	 */
+	public function test_older_wordpress_versions_are_rejected( string $version ): void {
+		$this->with_wp_version(
+			$version,
+			function () use ( $version ): void {
+				$this->assertFalse(
+					Service_Provider::is_supported_wp_version(),
+					sprintf( 'WordPress %s must be rejected.', $version )
+				);
+			}
+		);
+	}
+
+	/**
+	 * Ensures the floor itself and later releases are accepted.
+	 *
+	 * @dataProvider supported_versions
+	 *
+	 * @param string $version A WordPress version at or above the floor.
+	 */
+	public function test_supported_wordpress_versions_are_accepted( string $version ): void {
+		$this->with_wp_version(
+			$version,
+			function () use ( $version ): void {
+				$this->assertTrue(
+					Service_Provider::is_supported_wp_version(),
+					sprintf( 'WordPress %s must be accepted.', $version )
+				);
+			}
+		);
+	}
+
+	/**
+	 * Ensures the admin notice names both the requirement and the running version.
+	 */
+	public function test_unsupported_version_notice_reports_both_versions(): void {
+		$this->with_wp_version(
+			'6.6.2',
+			function (): void {
+				ob_start();
+				Service_Provider::render_unsupported_wp_version_notice();
+				$notice = (string) ob_get_clean();
+
+				$this->assertStringContainsString( 'notice-error', $notice );
+				$this->assertStringContainsString( '6.7', $notice );
+				$this->assertStringContainsString( '6.6.2', $notice );
+			}
+		);
+	}
+
+	/**
+	 * WordPress versions that must be rejected.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public static function unsupported_versions(): array {
+		return array(
+			'6.6.2'  => array( '6.6.2' ),
+			'6.6'    => array( '6.6' ),
+			'6.5.5'  => array( '6.5.5' ),
+			'5.9'    => array( '5.9' ),
+		);
+	}
+
+	/**
+	 * WordPress versions that must be accepted.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public static function supported_versions(): array {
+		return array(
+			'6.7'    => array( '6.7' ),
+			'6.7.1'  => array( '6.7.1' ),
+			'6.8'    => array( '6.8' ),
+			'7.0.2'  => array( '7.0.2' ),
+		);
+	}
+
+	/**
+	 * Run a callback with a temporarily overridden WordPress version.
+	 *
+	 * `get_bloginfo( 'version' )` reads the `$wp_version` global directly and applies
+	 * no filter for the raw context, so the global is the only seam available.
+	 *
+	 * @param string   $version  The version to report while the callback runs.
+	 * @param callable $callback The assertions to run.
+	 */
+	private function with_wp_version( string $version, callable $callback ): void {
+		$original = $GLOBALS['wp_version'];
+
+		$GLOBALS['wp_version'] = $version;
+
+		try {
+			$callback();
+		} finally {
+			$GLOBALS['wp_version'] = $original;
+		}
+	}
+}


### PR DESCRIPTION
Adds test coverage for every `WP_Exception` throw site in the dispatcher, and declares the WordPress 6.7 floor those throw sites depend on.

This started as a review of #8. That PR is obsolete — `main` already throws `WP_Exception` at all seven failure sites, and the patch conflicts. Closing it separately. What #8 exposed is that none of those throw sites had any test coverage.

## Exception coverage

`tests/phpunit/DispatcherExceptionTest.php` — 12 tests covering every reachable throw site. Action Scheduler only records an action as failed when the callback throws, so the exception contract is load-bearing for the queue. Each test pins both the exception type and the message identifier.

| Throw site | Identifier |
| --- | --- |
| `resolve_dispatch_data()` — schedule + immediate | `webhook_url_not_set` |
| `resolve_dispatch_data()` | `webhook_url_blocked` |
| `resolve_dispatch_data()` | `webhook_payload_invalid` |
| `resolve_dispatch_data()` | `webhook_payload_empty` |
| `get_webhook_from_headers()` | `webhook_not_found` |
| `send_webhook_request()` | `webhook_url_blocked` |
| `trigger_webhook_failure()` — both branches | `webhook_delivery_failed` |

Also covers the non-throwing opt-out branch (payload filter returning `false`) and the `catch` in `Webhook::emit()`, which must convert dispatcher exceptions into a warning rather than letting them escape.

One production change fell out of this: `get_webhook_from_headers()` raised `'Webhook not found in registry.'` while the other six sites used machine-matchable slugs. It now raises `webhook_not_found`. **This is a user-visible message change** — nothing in the codebase matches on the old string (the only consumer is the `trigger_error()` in `Webhook::emit()`, which prints it verbatim), but anything downstream matching on it would break.

## WordPress 6.7 requirement

`WP_Exception` was added to core in 6.7.0. Below that, every dispatcher throw site raises an uncatchable `Error: Class "WP_Exception" not found` — and `Webhook::emit()`'s `catch` cannot catch a fatal. The requirement was undeclared: no floor in `composer.json`, `"core": null` in `.wp-env.json`, nothing in the docs.

- **Declared** — Requirements table in `README.mdx` with the rationale.
- **Enforced at runtime** — `Service_Provider::MIN_WP_VERSION`, `is_supported_wp_version()`, and an early bail in `register()` that shows an admin notice instead of registering anything. It runs before `bootstrap_action_scheduler()`, so an unsupported site boots nothing. The check is a read of the `$wp_version` global plus one `version_compare()` — no DB query, and it runs once per request behind the existing `self::$registered` guard.
- **Enforced in CI** — `integration-tests.yml` now runs a matrix over `WP_ENV_CORE`: `WordPress/WordPress#6.7` and latest, with `fail-fast: false`.
- **Tested** — `tests/phpunit/RequirementsTest.php`, 11 tests: data-driven accept/reject around the boundary (`6.7`, `6.7.1`, `6.8`, `7.0.2` vs `6.6`, `6.6.2`, `6.5.5`, `5.9`) plus the notice content.

`composer.json` is unchanged — Composer cannot express a WordPress version constraint for a `type: library` package.

## Verification

Suite run against both matrix legs locally, after merging `main` (which required resolving a conflict in `register()` against #23's Action Scheduler bootstrap):

| WordPress | Result |
| --- | --- |
| 6.7 (floor) | 46 tests, 220 assertions — OK |
| 7.0.2 (latest) | 46 tests, 220 assertions — OK |

`phpstan` clean, `phpcs` clean.

Unrelated gap noticed while verifying: `composer phpcs` scans only the 20 files in `src/` despite `phpcs.xml` declaring `<file>.</file>`, so `tests/` gets no lint coverage. Left alone — fixing it will likely surface violations across the existing test files.